### PR TITLE
feat(persistence): add canonical player model

### DIFF
--- a/src/structured_freedom/persistence/__init__.py
+++ b/src/structured_freedom/persistence/__init__.py
@@ -1,2 +1,5 @@
-"""Persistence and database integration."""
+"""Persistence layer exports."""
 
+from structured_freedom.persistence.models import Player
+
+__all__ = ["Player"]

--- a/src/structured_freedom/persistence/models.py
+++ b/src/structured_freedom/persistence/models.py
@@ -1,0 +1,40 @@
+"""SQLAlchemy persistence models for Structured Freedom."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from structured_freedom.persistence.database import Base
+
+
+class Player(Base):
+    """Canonical persisted player state for the MVP."""
+
+    __tablename__ = "players"
+
+    id: Mapped[str] = mapped_column(
+        String(36),
+        primary_key=True,
+        default=lambda: str(uuid4()),
+    )
+    name: Mapped[str] = mapped_column(String(80), nullable=False)
+    location: Mapped[str] = mapped_column(String(80), default="village_square")
+    objective: Mapped[str] = mapped_column(
+        String(255),
+        default="Investigate the gate theft",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/tests/test_player_model.py
+++ b/tests/test_player_model.py
@@ -1,0 +1,44 @@
+from sqlalchemy import select
+from sqlalchemy.orm import sessionmaker
+
+from structured_freedom.persistence.database import Base, create_db_engine
+from structured_freedom.persistence.models import Player
+
+
+def _session_factory() -> sessionmaker:
+    engine = create_db_engine()
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+
+
+def test_player_model_persists_with_defaults() -> None:
+    session_factory = _session_factory()
+
+    with session_factory() as session:
+        session.add(Player(name="Aria"))
+        session.commit()
+
+        player = session.scalars(select(Player).where(Player.name == "Aria")).one()
+
+    assert player.id
+    assert player.location == "village_square"
+    assert player.objective == "Investigate the gate theft"
+
+
+def test_player_model_supports_explicit_state() -> None:
+    session_factory = _session_factory()
+
+    with session_factory() as session:
+        session.add(
+            Player(
+                name="Bram",
+                location="tavern",
+                objective="Ask the guard about the lock-down",
+            )
+        )
+        session.commit()
+
+        player = session.scalars(select(Player).where(Player.name == "Bram")).one()
+
+    assert player.location == "tavern"
+    assert player.objective == "Ask the guard about the lock-down"


### PR DESCRIPTION
### Motivation
- Provide a canonical persisted `Player` entity so the MVP can store and load player state for turns and scenarios.
- Capture minimal, testable player fields (identity, location, objective) and lifecycle timestamps to support save/reload and future rules logic.

### Description
- Add `src/structured_freedom/persistence/models.py` with a SQLAlchemy `Player` model containing `id`, `name`, `location`, `objective`, `created_at`, and `updated_at` fields.
- Export `Player` from `src/structured_freedom/persistence/__init__.py` so it is available as `structured_freedom.persistence.Player`.
- Add `tests/test_player_model.py` which creates an in-memory DB, bootstraps the schema, and verifies default values and explicit state persistence.
- Small formatting fix applied to satisfy `ruff` line-length rules in the new model file.

### Testing
- Ran `ruff check .` which returned no lint errors.
- Ran `pytest -q` and all tests passed: `6 passed`.
- New persistence tests exercise create/read behavior for the `Player` model and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c99bda0be88328a8b2ee794c631fed)