### PR TITLE
Add environment setup instructions to Windsurf config

### DIFF
--- a/.windsurfrules
+++ b/.windsurfrules
@@ -3,10 +3,25 @@ Read AGENTS.md first for shared conventions.
 You are a collaborator on Structured Freedom, an AI-based MUD generator.
 Multiple AI agents work on this repo. Follow the coordination rules in AGENTS.md strictly.
 
+## Setup (do this first)
+
+This project requires Python 3.12+. Use python3.12 explicitly, NOT the system default.
+Always create and use a virtual environment before running or installing anything:
+
+    python3.12 -m venv .venv
+    source .venv/bin/activate
+    pip install -e ".[dev]"
+
+Verify: python --version must show 3.12.x
+Never install packages globally or use a Python version older than 3.12.
+
+## Rules
+
 Branch prefix: windsurf/
 Check open PRs and recent commits before starting work.
 Write tests for all new code.
 Keep PRs small and focused.
 Follow existing patterns in the codebase.
+Run ruff check src/ tests/ and pytest before every commit.
 
 Tag @ironharvy before adding dependencies, changing structure, or making architectural decisions.

--- a/WINDSURF.md
+++ b/WINDSURF.md
@@ -6,12 +6,39 @@ Read `AGENTS.md` first for shared conventions.
 
 You are a collaborator on Structured Freedom, an AI-based MUD generator. Multiple AI agents work on this repo. Follow the coordination rules in AGENTS.md strictly.
 
+## Environment Setup
+
+Before writing any code, set up the project environment:
+
+1. **Use Python 3.12** — this project requires `python >= 3.12` (see `pyproject.toml`). Use `python3.12` explicitly, not the system default which may be an older version.
+2. **Create a virtual environment** in the project root:
+   ```bash
+   python3.12 -m venv .venv
+   ```
+3. **Activate the virtual environment**:
+   ```bash
+   source .venv/bin/activate
+   ```
+4. **Install dependencies** (including dev dependencies):
+   ```bash
+   pip install -e ".[dev]"
+   ```
+5. **Verify setup** before starting work:
+   ```bash
+   python --version  # must show 3.12.x
+   ruff check src/ tests/
+   pytest
+   ```
+
+Always run commands inside the activated `.venv`. Never install packages globally or use a Python version older than 3.12.
+
 ## Workflow
 
 - Always create a feature branch with the `windsurf/` prefix
 - Check open PRs and recent commits before starting work to avoid conflicts
 - Write tests for all new code
 - Keep PRs small and focused
+- Run `ruff check src/ tests/` and `pytest` before committing
 
 ## Code Style
 
@@ -32,3 +59,4 @@ Create an issue or PR comment tagging `@ironharvy` before:
 
 - All new features must include tests
 - Bug fixes must include a regression test
+- Run the full test suite before pushing


### PR DESCRIPTION
## Summary

- Adds explicit Python 3.12 requirement and venv setup steps to `WINDSURF.md` and `.windsurfrules`
- Ensures Windsurf uses `python3.12` (not system default) and always works inside `.venv`
- Adds pre-commit check reminders (`ruff check` + `pytest`)

## Context

Windsurf was not creating a venv and used the wrong Python version on its first task. These instructions make the setup requirements explicit so the agent follows the correct workflow from the start.

## Test plan

- [ ] Verify Windsurf reads `.windsurfrules` and creates `.venv` with Python 3.12 on next task
- [ ] Verify `ruff check` and `pytest` pass before Windsurf commits

https://claude.ai/code/session_012FYVXg1KNYZLejydYyGHxn