### PR TITLE
feat(mvp): AI layer, FastAPI API, React client, persistence, world content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ logs/
 
 # Coverage
 coverage/
+structured_freedom.db

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,337 +1,184 @@
-# Architecture
+# Architecture: Structured Freedom
 
-## Purpose
+> Last updated by: Tech Lead
+> Decision references: [DEC-0001]–[DEC-0010]
 
-This document defines the intended system architecture for Structured Freedom at
-the MVP stage and the design constraints that should survive later growth.
+## System Overview
 
-The primary goal is to support natural-language play inside a deterministic,
-persistent world where AI assists interpretation and narration without becoming
-the source of truth.
+Structured Freedom is a server-authoritative, single-player text adventure engine where an LLM assists with interpretation and narration but never controls canonical world state. The backend is a Python FastAPI service. The frontend is a React/Vite web client. The game engine is a deterministic rules layer that validates all actions before applying state changes.
 
-## Architectural Principles
+The primary architectural principle: **the engine is authoritative, AI is advisory**. Any LLM output that would bypass engine validation is silently ignored or narrated as a failed action.
 
-- The engine is authoritative over canonical state.
-- AI is an assistant to the engine, not a replacement for it.
-- Persistence is first-class.
-- Rejection behavior matters as much as success behavior.
-- The MVP should optimize for clarity and testability, not breadth.
-- The system should allow future model/provider expansion without premature
-  complexity.
+The turn pipeline is the system's critical path: raw player text → structured intent (AI) → engine validation → state mutation → prose narration (AI) → persistence → client response.
 
-## High-Level Shape
+## Technology Stack
 
-The architecture should be server-authoritative even though the MVP starts with
-a Python CLI client.
+| Area | Choice | Rationale |
+|------|--------|-----------|
+| Language | Python 3.12 | Existing codebase, strong typing, async support |
+| Web framework | FastAPI 0.115+ | Async-native, Pydantic-native, clean OpenAPI output |
+| ASGI server | Uvicorn | Standard FastAPI runtime |
+| AI orchestration | DSPy 2.6 | Typed signatures, structured outputs, provider-agnostic |
+| AI provider abstraction | LiteLLM | Single interface to Ollama, OpenAI, Anthropic |
+| Default LLM (dev) | Ollama (llama3.1:8b) | Local, free, fast enough for MVP validation |
+| ORM | SQLAlchemy 2.0 | Already in stack, async-capable, explicit schema |
+| Migrations | Alembic | Already installed, works with SQLAlchemy |
+| Database (dev) | SQLite | Zero-config local development |
+| Database (prod) | PostgreSQL 16 | Relational consistency for canonical state |
+| Domain models | Pydantic v2 | Already in use, excellent validation |
+| Testing | pytest | Already in use |
+| Frontend framework | React 18 + Vite | Fast dev server, TypeScript support, minimal config |
+| Frontend language | TypeScript | Type safety for API contract |
+| HTTP client (frontend) | fetch / axios | Standard; no heavy framework needed |
+| Linting | Ruff | Already in use |
 
-At a high level:
+> References: [DEC-0003], [DEC-0004], [DEC-0009], [DEC-0010]
 
-- client submits natural-language actions
-- application layer builds execution context
-- AI layer helps interpret or narrate
-- engine validates and resolves actions
-- persistence layer stores canonical results
-- client receives the final outcome
+## Component Breakdown
 
-## Main Components
+### Client (React/Vite)
+Responsibility: render game state and submit player actions to the API.
+Interfaces: REST `POST /api/turns`, `GET /api/sessions/{id}`.
+Contains: LocationPanel, GameLog, ActionInput, InventoryPanel, QuestPanel.
 
-### Client
+### API Layer (FastAPI)
+Responsibility: HTTP boundary — receive requests, delegate to app layer, return responses.
+Interfaces: `POST /api/sessions`, `GET /api/sessions/{id}`, `POST /api/sessions/{id}/turns`.
+Contains: session router, turn router, response schemas.
 
-MVP decision:
+### App Layer (Turn Orchestrator)
+Responsibility: coordinate a single turn from raw input to final result.
+Interfaces: `run_turn(session_id, action_text)` → `TurnResult`.
+Does not contain business rules or AI calls; it delegates to AI, Engine, and Persistence.
 
-- Python CLI client first
-
-Responsibilities:
-
-- collect player input
-- display narration and system feedback
-- show current location, inventory, and objective state
-- remain thin and disposable
-
-The client should not contain game rules or canonical state logic.
-
-### Application Layer
-
-This layer coordinates a turn from input to result.
-
-Responsibilities:
-
-- receive player action requests
-- load necessary world and player context
-- call AI services where appropriate
-- invoke deterministic validation and resolution
-- persist the outcome
-- format the response returned to the client
-
-This is orchestration code, not core simulation logic.
+### AI Layer (DSPy Modules)
+Responsibility: natural language ↔ structured data, constrained by explicit signatures.
+Sub-components:
+- `IntentInterpreter`: player text + world context → `ParsedIntent`
+- `Narrator`: `ActionResult` + world context → prose string
+- `NPCDialogue`: `NPCDialogueContext` + player speech → NPC response text
+Interfaces: all modules accept typed inputs and return typed outputs; never receive mutable state.
 
 ### Simulation Engine
-
-This is the core of the system.
-
-Responsibilities:
-
-- define canonical world rules
-- validate whether actions are possible
-- resolve state transitions
-- reject unsupported or impossible actions
-- protect world consistency
-
-This layer must remain deterministic as much as possible.
-
-Examples of decisions that belong here:
-
-- whether a door is locked
-- whether the player has an item
-- whether an NPC is present
-- whether a claimed action is physically or fictionally possible in the world
-- what state changes occur after a successful action
-
-### AI Layer
-
-The AI layer should be a bounded subsystem behind explicit interfaces.
-
-MVP responsibilities:
-
-- intent interpretation
-- narration generation
-
-Later responsibilities:
-
-- NPC dialogue support
-- summarization
-- memory distillation
-- story seeding
-
-The AI layer must not directly mutate canonical state.
+Responsibility: validate intents against world state and apply deterministic state transitions.
+Interfaces: `validate_*(player, world, ...)` → `ActionResult`; `resolve_*(player, world, ...)` → None.
+Already implemented for: move, take, drop, use. Needs: examine, talk, custom action routing.
 
 ### Persistence Layer
+Responsibility: save and load canonical game state (player, world, NPCs, quests).
+Sub-components:
+- `ORM models`: SQLAlchemy table definitions
+- `Repository`: `GameRepository` with load/save per entity
+- `database.py`: engine + session factory
+Interfaces: `GameRepository.load_session(id)`, `GameRepository.save_session(session)`.
 
-Responsibilities:
+### World / Fixtures
+Responsibility: define the canonical MVP world content.
+Sub-components:
+- `fixtures.py`: locations, items, NPCs, initial world state for MVP scenario
+- `scenario.py`: quest definitions and initial world flags for the village gate scenario
 
-- store canonical player and world state
-- store quest and objective progression
-- store event history
-- load state needed for each turn
-- support save/reload and test isolation
+## Data Model
 
-This layer should hide database-specific details from the engine.
+### Session
+Top-level container: player state + world state + NPCs for one playthrough.
+Fields: `id`, `player`, `world`, `npcs: dict[str, NPC]`, `turn_number`, `created_at`, `updated_at`.
+
+### Player (existing)
+Fields: `id`, `name`, `current_location`, `stats`, `inventory`, `quests`.
+
+### WorldState (existing)
+Fields: `locations: dict[str, Location]`, `items: dict[str, Item]`, `flags: dict[str, bool]`.
+
+### Location (existing)
+Fields: `id`, `name`, `description`, `connections: dict[str, str]`.
+
+### Item (existing)
+Fields: `id`, `name`, `description`, `location_id`, `takeable`, `usable`.
+
+### NPC (existing)
+Fields: `id`, `name`, `role`, `description`, `current_location`, `disposition`, `state`, `memory`.
+
+### TurnRecord
+Append-only event log entry per turn.
+Fields: `id`, `session_id`, `turn_number`, `raw_input`, `parsed_intent`, `validation_success`, `state_changes`, `narration`, `created_at`.
 
 ## Turn Pipeline
 
-The core turn loop should work like this:
-
-1. The client submits a natural-language action.
-2. The application layer loads current player and world context.
-3. The AI intent interpreter converts the input into structured intent.
-4. The engine validates the structured intent against actual world state.
-5. If invalid, the engine returns a rejection result.
-6. If valid, the engine resolves deterministic state changes.
-7. The AI narration layer generates a response from the validated result.
-8. The persistence layer stores the updated canonical state and event record.
-9. The client receives the final result.
-
-Important rule:
-
-- AI may help interpret what the player means
-- AI may help narrate what happened
-- the engine decides what actually happened
-
-## Handling Invalid Or Absurd Actions
-
-This system must resist the normal failure mode of unconstrained LLM apps:
-accepting impossible inputs because they are easy to improvise around.
-
-Examples:
-
-- "I build a rocketship and fly away."
-- "I take a bazooka out of my ass and fire at the king."
-- "I teleport into the vault."
-
-Required behavior:
-
-- the intent layer can classify these actions
-- the engine must reject them if the world does not support them
-- the narrator should explain the rejection in-world or systemically
-- persistence should record no illegal state transition
-
-This rejection path is a core feature, not an edge case.
-
-## State Model
-
-The canonical state should remain structured and explicit.
-
-MVP state categories:
-
-- player
-- locations
-- items
-- NPCs
-- quests or objectives
-- world flags
-- event history
-
-Suggested conceptual entities:
-
-- `Player`
-- `Location`
-- `Item`
-- `Npc`
-- `Quest`
-- `WorldEvent`
-- `ActionResult`
-
-Generated narration should not be treated as canonical state. It is a derived
-artifact attached to validated outcomes.
-
-## Persistence Strategy
-
-Recommended primary store:
-
-- `PostgreSQL`
-
-Recommended MVP usage:
-
-- store canonical world state in relational tables
-- store event history for debugging and replay
-- keep schema explicit for inventory, locations, NPC state, and quest progress
-
-Optional supporting stores later:
-
-- `Redis` for cache or background jobs
-- document storage for generated artifacts if needed
-- object storage for media
-
-The MVP does not require MongoDB Atlas.
-
-## AI Provider Architecture
-
-The system should support multiple providers eventually, but the MVP should
-implement one provider and one model first.
-
-Current MVP decision:
-
-- start with local `Ollama`
-- design interfaces so other providers can be added later
-
-Provider abstraction should separate:
-
-- model invocation
-- prompt or signature definition
-- task-level orchestration
-
-The engine should not care whether the underlying provider is Ollama, OpenAI,
-Anthropic, or something else.
-
-## DSPy Role
-
-`DSPy` should be the preferred way to structure AI interactions.
-
-Recommended uses in MVP:
-
-- intent extraction into structured action candidates
-- narration generation from validated action results
-
-Rules:
-
-- keep DSPy modules task-specific
-- prefer typed or schema-constrained outputs
-- validate all outputs before use
-- version prompts or signatures intentionally
-
-Avoid:
-
-- embedding large ad hoc prompts throughout the codebase
-- letting DSPy modules bypass domain rules
-- mixing narration concerns with simulation concerns
-
-## Configuration Strategy
-
-`.env` should hold environment-specific values and secrets, but it should not
-become the whole configuration system.
-
-Recommended pattern:
-
-- `.env` stores environment variables and credentials
-- application config code loads and validates them
-- model/task mapping lives in typed config, not scattered string lookups
-
-For MVP, one model is enough.
-
-Suggested MVP approach:
-
-- `.env` contains provider choice, base URL, and default model
-- a Python config module loads these values
-- later, task-specific model routing can move into structured config
-
-This keeps the MVP simple while leaving room for later:
-
-- separate intent and narration models
-- per-environment overrides
-- provider-specific defaults
-
-## Suggested Code Boundaries
-
-One reasonable early structure is:
-
-- `src/config/`
-- `src/engine/`
-- `src/ai/`
-- `src/persistence/`
-- `src/app/`
-- `src/client/`
-- `tests/`
-
-Responsibility split:
-
-- `config`: typed settings and environment loading
-- `engine`: rules, validation, world logic, state transitions
-- `ai`: DSPy modules, provider clients, response shaping
-- `persistence`: repositories, database models, migrations
-- `app`: turn orchestration and service entry points
-- `client`: Python CLI MVP interface
-
-## Logging And Observability
-
-The system should log the turn pipeline clearly.
-
-Minimum logging per action:
-
-- player action input
-- parsed structured intent
-- validation outcome
-- applied state changes
-- AI narration request and result boundaries
-- persistence success or failure
-
-Local development logs should be colored and readable. Production logging can be
-more structured and less decorative later.
-
-## Testing Strategy
-
-Architecture must support testing from the start.
-
-Priority test layers:
-
-- unit tests for engine validation and rules
-- unit tests for AI output parsing and contracts
-- integration tests for turn execution
-- persistence tests for save/reload behavior
-- regression tests for impossible or world-breaking prompts
-
-The most important invariant is:
-
-- no AI-generated output should be able to bypass engine rules and become canon
-
-## MVP Implementation Bias
-
-At MVP stage, choose the simpler option when there is doubt:
-
-- Python CLI before web client
-- one AI provider before many providers
-- one model before per-task model routing
-- explicit state tables before flexible document-heavy storage
-- deterministic rule checks before agentic autonomy
-
-The architecture should remain extensible, but the MVP should not be burdened
-by solving future complexity too early.
+```
+1. Client  → POST /api/sessions/{id}/turns  { "action": "..." }
+2. API     → TurnOrchestrator.run_turn(session_id, action_text)
+3. App     → load Session from repository
+4. AI      → IntentInterpreter.parse(action_text, world_context) → ParsedIntent
+5. Engine  → validate_*(player, world, intent) → ActionResult
+           → if invalid: skip to step 8
+6. Engine  → resolve_*(player, world, intent) → mutate state
+7. Persist → repository.save_session(session)
+8. AI      → Narrator.narrate(action_result, world_context) → prose
+9. Persist → repository.append_turn_record(turn)
+10. API    → return TurnResponse { success, narration, state_snapshot }
+```
+
+## API Design
+
+Base path: `/api`
+Auth: none (MVP)
+Content-type: `application/json`
+
+```
+POST   /api/sessions                → create new session, returns session_id + initial state
+GET    /api/sessions/{id}           → get current session state
+POST   /api/sessions/{id}/turns     → execute a turn, returns TurnResponse
+GET    /api/sessions/{id}/turns     → turn history
+```
+
+Response shapes are defined as Pydantic models in `app/api/schemas.py`.
+
+## Coding Standards
+
+- All new modules in `src/structured_freedom/`
+- DSPy modules live in `src/structured_freedom/ai/`
+- ORM models live in `src/structured_freedom/persistence/orm/`
+- Repositories live in `src/structured_freedom/persistence/repositories/`
+- World content lives in `src/structured_freedom/world/`
+- FastAPI app and routers live in `src/structured_freedom/app/`
+- No raw LLM prompts outside DSPy signatures
+- Engine functions remain pure (no I/O, no AI calls)
+- All public functions have type annotations
+- Test files mirror source structure under `tests/`
+
+## Infrastructure
+
+### Project Structure
+```
+structured_freedom/
+├── src/structured_freedom/
+│   ├── ai/             # DSPy modules
+│   ├── app/            # FastAPI app + turn orchestrator
+│   ├── client/         # CLI (keep for debugging)
+│   ├── config/         # Settings
+│   ├── engine/         # Deterministic rules
+│   ├── models/         # Pydantic domain models
+│   ├── persistence/    # ORM + repositories
+│   └── world/          # Fixtures + scenario content
+├── frontend/           # React/Vite web client
+│   ├── src/
+│   │   ├── api/        # API client
+│   │   ├── components/ # UI components
+│   │   └── types/      # TypeScript types
+│   └── package.json
+├── alembic/            # Database migrations
+├── docs/
+└── tests/
+```
+
+### CI/CD Pipeline
+Stages: ruff lint → pytest → (frontend: npm ci + tsc + vitest)
+
+### Containerization
+Dockerfile: multi-stage, Python backend + static frontend build. Not required for MVP local dev.
+
+## Open Questions
+- SPIKE-001: DSPy structured output reliability with local Ollama — test before committing to ChainOfThought vs Predict
+- SPIKE-002: WebSocket streaming for narration (post-MVP)
+- SPIKE-003: World artifact ingestion format

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -112,3 +112,41 @@ entry instead of silently rewriting history.
   - shared live edits in one folder create avoidable conflicts and stale state
 - Notes:
   - same-folder parallel work should be treated as a fallback, not the default
+
+## D-009 React Frontend Replaces CLI-First Decision
+
+- Status: `active`
+- Date: `2026-04-16`
+- Decision: The primary client for MVP is a React/Vite/TypeScript web UI. D-002 (Python CLI first) is superseded.
+- Why:
+  - user confirmed React as the target frontend during intake
+  - the core gameplay loop (location panel, action log, inventory) maps naturally to a web layout
+  - the CLI is retained as a debug/development utility only
+- Notes:
+  - supersedes D-002
+  - frontend lives in `frontend/` at repo root
+
+## D-010 LiteLLM As Provider Abstraction For DSPy
+
+- Status: `active`
+- Date: `2026-04-16`
+- Decision: All DSPy LM calls route through LiteLLM, which is already installed. Provider (Ollama, OpenAI, Anthropic) is set via `AI_PROVIDER` env var.
+- Why:
+  - LiteLLM is already in the venv
+  - single switch to change providers without code changes
+  - consistent interface for Ollama (local dev) and cloud providers (production)
+- Notes:
+  - default dev provider remains Ollama (D-004 still active for local dev)
+  - production provider to be decided when cloud deployment is scoped
+
+## D-011 FastAPI Added As Backend Framework
+
+- Status: `active`
+- Date: `2026-04-16`
+- Decision: FastAPI + Uvicorn added as the HTTP layer. `fastapi` and `uvicorn[standard]` added to `pyproject.toml` dependencies.
+- Why:
+  - async-native, Pydantic v2-native, OpenAPI docs out of the box
+  - already referenced in `docs/mvp.md` technical baseline
+- Notes:
+  - `httpx` added to dev dependencies for async test client
+  - new dependencies require human review per AGENTS.md before merge

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,64 @@
+# Requirements: Structured Freedom
+
+> Last updated by: Business Analyst
+> Decision references: [DEC-0001], [DEC-0002], [DEC-0003], [DEC-0004], [DEC-0005], [DEC-0006], [DEC-0009]
+
+## Functional Requirements
+
+| ID | Priority | Description |
+|----|----------|-------------|
+| FR-001 | must-have | Player can start a new game session; system creates player state and loads the MVP world |
+| FR-002 | must-have | Player can type any free-form natural language action |
+| FR-003 | must-have | System interprets free-form input into a structured intent (action type, target, parameters) using an LLM |
+| FR-004 | must-have | Engine validates the structured intent against canonical world state; physically impossible actions are rejected |
+| FR-005 | must-have | On success, engine applies deterministic state changes (movement, item pickup, NPC state updates) |
+| FR-006 | must-have | AI narrates the validated outcome in atmospheric prose; narrative does not alter canonical state |
+| FR-007 | must-have | Player can move between connected locations |
+| FR-008 | must-have | Player can take, drop, and use items |
+| FR-009 | must-have | Player can examine locations, NPCs, and items to get descriptions |
+| FR-010 | must-have | Player can talk to NPCs; NPCs respond using AI dialogue grounded in their role, state, and memory |
+| FR-011 | must-have | NPCs have bounded memory (last N interactions) that influences their responses |
+| FR-012 | must-have | The game world includes the MVP scenario: village, tavern, market, gate, forest edge |
+| FR-013 | must-have | The MVP scenario contains 3–5 NPCs, a short quest, and a set of interactive items |
+| FR-014 | must-have | Game state (player, world, NPCs, quests) persists across server restarts |
+| FR-015 | must-have | World state is loaded from a canonical fixture at session start |
+| FR-016 | must-have | Impossible or absurd actions (rocketships, teleportation, bazooka) are rejected with an in-world explanation |
+| FR-017 | must-have | React web client displays: current location, action log, inventory, quest objectives |
+| FR-018 | must-have | React web client accepts free-form text input and submits turns to the backend |
+| FR-019 | should-have | Player can perform complex multi-part actions ("pick up the lantern and examine it") |
+| FR-020 | should-have | Quest progression is tracked; completing objectives updates player state |
+| FR-021 | should-have | NPC disposition can shift (friendly → hostile) based on player actions |
+| FR-022 | nice-to-have | WebSocket transport for real-time response streaming |
+| FR-023 | nice-to-have | Image generation via Replicate (Flux model) for locations and NPCs |
+| FR-024 | nice-to-have | Music generation via Suno API for ambient atmosphere |
+
+## Non-Functional Requirements
+
+| ID | Category | Description |
+|----|----------|-------------|
+| NFR-001 | performance | Turn round-trip (excluding LLM call) < 50ms at p95 |
+| NFR-002 | performance | LLM intent interpretation + narration: no hard SLA; progress indicator on frontend |
+| NFR-003 | reliability | No LLM output should be able to mutate canonical world state directly |
+| NFR-004 | reliability | Engine rejection must produce no state transition; world state is unchanged on invalid action |
+| NFR-005 | testability | Engine rules must be testable without a live LLM (mock AI layer in tests) |
+| NFR-006 | security | No authentication required for MVP (single-player, local deployment) |
+| NFR-007 | maintainability | AI provider is swappable via config (Ollama ↔ OpenAI ↔ Anthropic) without code changes |
+| NFR-008 | maintainability | DSPy modules are versioned and documented; prompts are not scattered ad hoc |
+| NFR-009 | observability | Each turn logs: raw input, parsed intent, validation outcome, state changes, narration boundaries |
+
+## Constraints
+
+- No existing MUD framework; custom engine required
+- Python 3.12, FastAPI backend
+- React + Vite frontend (TypeScript)
+- PostgreSQL for production; SQLite acceptable for local development
+- DSPy for all structured AI calls
+- LiteLLM as the provider abstraction layer (supports Ollama, OpenAI, Anthropic)
+- AI layer must not directly mutate canonical state (engine is authoritative)
+- MVP excludes: images, music, story generation integration, multiplayer
+
+## Open Questions / Research Spikes
+
+- [SPIKE-001] DSPy structured output reliability with local Ollama models — do we need ChainOfThought or is Predict sufficient for intent parsing?
+- [SPIKE-002] WebSocket vs. HTTP long-poll for streaming narration — evaluate for post-MVP
+- [SPIKE-003] How to load world artifacts (world bible, character sheets) into the fixture system — format and tooling

--- a/docs/sprint-backlog.md
+++ b/docs/sprint-backlog.md
@@ -1,0 +1,173 @@
+# Sprint Backlog: Structured Freedom
+
+> Last updated by: Project Manager
+
+## Sprint 1 — Core Turn Loop (Backend)
+
+Goal: A player can submit a turn via the API and receive a validated, narrated response backed by real AI interpretation.
+
+### [EPIC-001] AI Layer
+
+Outcome: DSPy modules interpret player intent, narrate outcomes, and generate NPC dialogue.
+
+#### [STORY-001] Intent Interpreter
+As a player, I want my natural language input to be understood as a structured game action.
+
+Acceptance criteria:
+- [ ] `IntentInterpreter` returns a `ParsedIntent` with `action_type`, `target`, `is_plausible`, `rejection_reason`
+- [ ] Absurd inputs return `is_plausible=False` with a reason
+- [ ] Common verbs (move, take, drop, use, examine, talk) are correctly classified
+
+Tasks:
+- [TASK-001] Create `src/structured_freedom/ai/intent.py` with DSPy `IntentInterpreter` — @developer — 1d
+- [TASK-002] Create `src/structured_freedom/ai/provider.py` to configure DSPy LM from settings — @developer — 0.5d
+- [TASK-003] Unit tests for intent classification — @qa — 0.5d
+
+#### [STORY-002] Narrator
+As a player, I want action outcomes narrated in atmospheric prose.
+
+Acceptance criteria:
+- [ ] `Narrator` accepts `ActionResult` + world context and returns prose string
+- [ ] Narration correctly reflects success vs. rejection
+- [ ] Narration does not invent facts not present in `ActionResult`
+
+Tasks:
+- [TASK-004] Create `src/structured_freedom/ai/narrator.py` — @developer — 0.5d
+- [TASK-005] Unit tests for narrator output contracts — @qa — 0.5d
+
+#### [STORY-003] NPC Dialogue
+As a player, I want NPCs to respond in character with awareness of their state and memory.
+
+Acceptance criteria:
+- [ ] `NPCDialogue` accepts `NPCDialogueContext` + player speech and returns NPC response text
+- [ ] Response is grounded in NPC role and disposition
+- [ ] Response references recent memory entries when relevant
+
+Tasks:
+- [TASK-006] Create `src/structured_freedom/ai/dialogue.py` — @developer — 1d
+- [TASK-007] Unit tests for dialogue module — @qa — 0.5d
+
+---
+
+### [EPIC-002] FastAPI Application
+
+Outcome: Backend exposes a working REST API for session management and turn execution.
+
+#### [STORY-004] Session Management
+As a player, I want to create a game session and have my state tracked.
+
+Acceptance criteria:
+- [ ] `POST /api/sessions` returns a new session ID and initial world snapshot
+- [ ] `GET /api/sessions/{id}` returns current session state
+
+Tasks:
+- [TASK-008] Create `src/structured_freedom/app/api/` with FastAPI app and session router — @developer — 1d
+- [TASK-009] Create Pydantic response schemas in `app/api/schemas.py` — @developer — 0.5d
+- [TASK-010] Integration test: create session returns valid state snapshot — @qa — 0.5d
+
+#### [STORY-005] Turn Execution
+As a player, I want to submit an action and receive a narrated outcome.
+
+Acceptance criteria:
+- [ ] `POST /api/sessions/{id}/turns` with `{"action": "..."}` returns `TurnResponse`
+- [ ] `TurnResponse` contains `success`, `narration`, `state_snapshot`
+- [ ] Invalid session ID returns 404
+- [ ] Impossible actions return `success=false` with in-world narration
+
+Tasks:
+- [TASK-011] Update `app/turns.py` to full pipeline: load → AI intent → engine → persist → AI narrate — @developer — 2d
+- [TASK-012] Create turn router in `app/api/` — @developer — 0.5d
+- [TASK-013] Integration tests for turn execution — @qa — 1d
+
+---
+
+### [EPIC-003] Persistence
+
+Outcome: Game state survives server restarts.
+
+#### [STORY-006] ORM and Repository
+As a developer, I want a clean persistence layer that separates domain models from database tables.
+
+Acceptance criteria:
+- [ ] SQLAlchemy ORM models for Session, TurnRecord
+- [ ] `GameRepository` implements `create_session`, `load_session`, `save_session`, `append_turn`
+- [ ] Repository tests pass with SQLite in-memory
+
+Tasks:
+- [TASK-014] Create `persistence/orm/models.py` with SQLAlchemy table definitions — @developer — 1d
+- [TASK-015] Create `persistence/repositories/game_repo.py` — @developer — 1d
+- [TASK-016] Alembic migration for initial schema — @devops — 0.5d
+- [TASK-017] Repository unit tests — @qa — 1d
+
+---
+
+### [EPIC-004] World Content
+
+Outcome: The MVP scenario is playable from start to finish.
+
+#### [STORY-007] MVP Fixtures
+As a player, I want to start in a believable village world with interactive NPCs and items.
+
+Acceptance criteria:
+- [ ] World contains 5 locations (village, tavern, market, gate, forest_edge)
+- [ ] World contains at least 5 interactive items
+- [ ] World contains 4 NPCs (innkeeper, guard, merchant, mysterious stranger)
+- [ ] Guard blocks the gate north passage (world flag: `gate_north_blocked=True`)
+
+Tasks:
+- [TASK-018] Create `src/structured_freedom/world/fixtures.py` with MVP world content — @developer — 1d
+- [TASK-019] Create `src/structured_freedom/world/scenario.py` with quest definitions — @developer — 0.5d
+- [TASK-020] Smoke test: fixture loads without errors and passes world validators — @qa — 0.5d
+
+---
+
+## Sprint 2 — React Frontend
+
+Goal: A player can play the full MVP scenario through the web UI.
+
+### [EPIC-005] React Web Client
+
+Outcome: Players interact with the game through a functional browser-based UI.
+
+#### [STORY-008] Game Layout
+As a player, I want a clear UI showing my location, inventory, and action log.
+
+Acceptance criteria:
+- [ ] LocationPanel shows current location name and description
+- [ ] GameLog shows the last N turn narrations
+- [ ] InventoryPanel shows current items held
+- [ ] QuestPanel shows active and completed objectives
+- [ ] ActionInput accepts free-form text and submits on Enter or button press
+
+Tasks:
+- [TASK-021] Scaffold Vite + React + TypeScript project in `frontend/` — @devops — 0.5d
+- [TASK-022] Create TypeScript API types matching backend schemas — @developer — 0.5d
+- [TASK-023] Create API client (`frontend/src/api/client.ts`) — @developer — 0.5d
+- [TASK-024] Implement LocationPanel component — @developer — 0.5d
+- [TASK-025] Implement GameLog component — @developer — 0.5d
+- [TASK-026] Implement InventoryPanel and QuestPanel components — @developer — 0.5d
+- [TASK-027] Implement ActionInput component — @developer — 0.5d
+- [TASK-028] Wire App.tsx to API client with session lifecycle — @developer — 1d
+
+#### [STORY-009] Loading and Error States
+As a player, I want clear feedback while the AI is thinking and when things go wrong.
+
+Acceptance criteria:
+- [ ] Loading spinner shown while turn is processing
+- [ ] Error messages shown when the API returns an error
+- [ ] Input is disabled while processing to prevent double-submission
+
+Tasks:
+- [TASK-029] Add loading/error state handling to App.tsx — @developer — 0.5d
+
+---
+
+## Sprint 3 — Polish & Post-MVP
+
+- [EPIC-006] Image generation via Replicate (Flux) — post-MVP
+- [EPIC-007] Music generation via Suno API — post-MVP
+- [EPIC-008] WebSocket streaming narration — post-MVP
+- [EPIC-009] Story artifact ingestion tool — post-MVP
+- [SPIKE-001] DSPy structured output evaluation with Ollama
+- [SPIKE-002] WebSocket streaming feasibility
+- [SPIKE-003] World artifact format specification

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Structured Freedom</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body {
+        background: #0d0d0d;
+        color: #c9b99a;
+        font-family: 'Courier New', monospace;
+        font-size: 15px;
+        line-height: 1.6;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "structured-freedom-client",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.3",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,127 @@
+import { useState, useEffect, useCallback } from 'react';
+import { createSession, executeTurn } from './api/client';
+import { LocationPanel } from './components/LocationPanel';
+import { GameLog } from './components/GameLog';
+import { InventoryPanel } from './components/InventoryPanel';
+import { QuestPanel } from './components/QuestPanel';
+import { ActionInput } from './components/ActionInput';
+import type { StateSnapshot, LogEntry } from './types/game';
+
+let logCounter = 0;
+
+export default function App() {
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [state, setState] = useState<StateSnapshot | null>(null);
+  const [log, setLog] = useState<LogEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    createSession('Traveller')
+      .then((res) => {
+        setSessionId(res.session_id);
+        setState(res.state);
+        setLog([{
+          id: ++logCounter,
+          input: '',
+          narration: `Welcome to Ashford. ${res.state.location_description}`,
+          success: true,
+        }]);
+      })
+      .catch((e) => setError(String(e)));
+  }, []);
+
+  const handleAction = useCallback(async (action: string) => {
+    if (!sessionId || loading) return;
+    setLoading(true);
+    try {
+      const res = await executeTurn(sessionId, action);
+      setState(res.state);
+      setLog((prev) => [
+        ...prev,
+        { id: ++logCounter, input: action, narration: res.narration, success: res.success },
+      ]);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId, loading]);
+
+  if (error) {
+    return (
+      <div style={styles.error}>
+        <div>Error: {error}</div>
+        <div style={{ marginTop: '0.5rem', fontSize: '0.85rem', color: '#806060' }}>
+          Make sure the backend is running on port 8000.
+        </div>
+      </div>
+    );
+  }
+
+  if (!state) {
+    return <div style={styles.loading}>Loading world…</div>;
+  }
+
+  return (
+    <div style={styles.layout}>
+      <div style={styles.main}>
+        <LocationPanel state={state} />
+        <GameLog entries={log} loading={loading} />
+        <ActionInput onSubmit={handleAction} disabled={loading} />
+      </div>
+      <div style={styles.sidebar}>
+        <InventoryPanel inventory={state.inventory} />
+        <QuestPanel quests={state.quests} />
+        <div style={styles.turnCounter}>Turn {state.turn_number}</div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  layout: {
+    display: 'flex',
+    height: '100vh',
+    maxWidth: '1100px',
+    margin: '0 auto',
+    padding: '1.5rem',
+    gap: '1.5rem',
+  },
+  main: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column' as const,
+    minWidth: 0,
+  },
+  sidebar: {
+    width: '220px',
+    flexShrink: 0,
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: '0.5rem',
+  },
+  error: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100vh',
+    color: '#c05050',
+    fontFamily: 'Courier New, monospace',
+  },
+  loading: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100vh',
+    color: '#7a6a50',
+    fontFamily: 'Courier New, monospace',
+  },
+  turnCounter: {
+    color: '#4a4030',
+    fontSize: '0.75rem',
+    textAlign: 'right' as const,
+    marginTop: 'auto',
+  },
+};

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,29 @@
+import type { SessionResponse, TurnResponse } from '../types/game';
+
+const BASE = '/api';
+
+export async function createSession(playerName = 'Traveller'): Promise<SessionResponse> {
+  const res = await fetch(`${BASE}/sessions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ player_name: playerName }),
+  });
+  if (!res.ok) throw new Error(`Failed to create session: ${res.status}`);
+  return res.json();
+}
+
+export async function getSession(sessionId: string): Promise<SessionResponse> {
+  const res = await fetch(`${BASE}/sessions/${sessionId}`);
+  if (!res.ok) throw new Error(`Session not found: ${res.status}`);
+  return res.json();
+}
+
+export async function executeTurn(sessionId: string, action: string): Promise<TurnResponse> {
+  const res = await fetch(`${BASE}/sessions/${sessionId}/turns`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action }),
+  });
+  if (!res.ok) throw new Error(`Turn failed: ${res.status}`);
+  return res.json();
+}

--- a/frontend/src/components/ActionInput.tsx
+++ b/frontend/src/components/ActionInput.tsx
@@ -1,0 +1,64 @@
+import { useState, type KeyboardEvent } from 'react';
+
+interface Props {
+  onSubmit: (action: string) => void;
+  disabled: boolean;
+}
+
+export function ActionInput({ onSubmit, disabled }: Props) {
+  const [value, setValue] = useState('');
+
+  const submit = () => {
+    const trimmed = value.trim();
+    if (!trimmed || disabled) return;
+    onSubmit(trimmed);
+    setValue('');
+  };
+
+  const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') submit();
+  };
+
+  return (
+    <div style={styles.container}>
+      <span style={styles.prompt}>&gt;</span>
+      <input
+        style={styles.input}
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKey}
+        disabled={disabled}
+        placeholder={disabled ? 'Thinking...' : 'What do you do?'}
+        autoFocus
+        autoComplete="off"
+        spellCheck={false}
+      />
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    borderTop: '1px solid #3a3020',
+    paddingTop: '0.75rem',
+    marginTop: '0.5rem',
+    gap: '0.5rem',
+  },
+  prompt: {
+    color: '#6a8a6a',
+    fontSize: '1rem',
+    flexShrink: 0,
+  },
+  input: {
+    flex: 1,
+    background: 'transparent',
+    border: 'none',
+    outline: 'none',
+    color: '#d4c080',
+    fontFamily: 'inherit',
+    fontSize: '0.95rem',
+  },
+};

--- a/frontend/src/components/GameLog.tsx
+++ b/frontend/src/components/GameLog.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+import type { LogEntry } from '../types/game';
+
+interface Props {
+  entries: LogEntry[];
+  loading: boolean;
+}
+
+export function GameLog({ entries, loading }: Props) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [entries, loading]);
+
+  return (
+    <div style={styles.container}>
+      {entries.map((e) => (
+        <div key={e.id} style={styles.entry}>
+          <span style={styles.prompt}>&gt; </span>
+          <span style={styles.input}>{e.input}</span>
+          <div style={{ ...styles.narration, color: e.success ? '#c9b99a' : '#a05050' }}>
+            {e.narration}
+          </div>
+        </div>
+      ))}
+      {loading && (
+        <div style={styles.thinking}>
+          <span style={styles.prompt}>&gt; </span>
+          <span style={styles.blink}>▋</span>
+        </div>
+      )}
+      <div ref={bottomRef} />
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    flex: 1,
+    overflowY: 'auto' as const,
+    padding: '0.5rem 0',
+    minHeight: 0,
+  },
+  entry: {
+    marginBottom: '1rem',
+  },
+  prompt: {
+    color: '#6a8a6a',
+  },
+  input: {
+    color: '#d4c080',
+  },
+  narration: {
+    marginTop: '0.3rem',
+    paddingLeft: '1.2rem',
+    lineHeight: '1.7',
+  },
+  thinking: {
+    color: '#6a8a6a',
+  },
+  blink: {
+    animation: 'blink 1s step-start infinite',
+  },
+};

--- a/frontend/src/components/InventoryPanel.tsx
+++ b/frontend/src/components/InventoryPanel.tsx
@@ -1,0 +1,50 @@
+interface Props {
+  inventory: string[];
+}
+
+export function InventoryPanel({ inventory }: Props) {
+  return (
+    <div style={styles.container}>
+      <div style={styles.title}>Inventory</div>
+      {inventory.length === 0 ? (
+        <div style={styles.empty}>Nothing carried.</div>
+      ) : (
+        <ul style={styles.list}>
+          {inventory.map((item) => (
+            <li key={item} style={styles.item}>{item}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    borderTop: '1px solid #3a3020',
+    paddingTop: '0.75rem',
+    marginTop: '0.5rem',
+  },
+  title: {
+    color: '#e8c87a',
+    fontWeight: 'bold' as const,
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+    marginBottom: '0.4rem',
+    fontSize: '0.85rem',
+  },
+  empty: {
+    color: '#5a5040',
+    fontStyle: 'italic' as const,
+    fontSize: '0.85rem',
+  },
+  list: {
+    listStyle: 'none',
+    padding: 0,
+  },
+  item: {
+    color: '#b0a880',
+    fontSize: '0.85rem',
+    padding: '0.1rem 0',
+  },
+};

--- a/frontend/src/components/LocationPanel.tsx
+++ b/frontend/src/components/LocationPanel.tsx
@@ -1,0 +1,34 @@
+import type { StateSnapshot } from '../types/game';
+
+interface Props {
+  state: StateSnapshot;
+}
+
+export function LocationPanel({ state }: Props) {
+  return (
+    <div style={styles.container}>
+      <div style={styles.name}>{state.location_name}</div>
+      <div style={styles.description}>{state.location_description}</div>
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    borderBottom: '1px solid #3a3020',
+    paddingBottom: '0.75rem',
+    marginBottom: '0.75rem',
+  },
+  name: {
+    color: '#e8c87a',
+    fontWeight: 'bold',
+    fontSize: '1.05rem',
+    marginBottom: '0.3rem',
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+  },
+  description: {
+    color: '#a89070',
+    fontStyle: 'italic' as const,
+  },
+};

--- a/frontend/src/components/QuestPanel.tsx
+++ b/frontend/src/components/QuestPanel.tsx
@@ -1,0 +1,56 @@
+import type { QuestInfo } from '../types/game';
+
+interface Props {
+  quests: Record<string, QuestInfo>;
+}
+
+export function QuestPanel({ quests }: Props) {
+  const entries = Object.entries(quests);
+  if (entries.length === 0) return null;
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.title}>Objectives</div>
+      {entries.map(([id, q]) => (
+        <div key={id} style={styles.quest}>
+          {q.active.map((obj) => (
+            <div key={obj} style={styles.active}>◇ {obj}</div>
+          ))}
+          {q.completed.map((obj) => (
+            <div key={obj} style={styles.completed}>◆ {obj}</div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    borderTop: '1px solid #3a3020',
+    paddingTop: '0.75rem',
+    marginTop: '0.5rem',
+  },
+  title: {
+    color: '#e8c87a',
+    fontWeight: 'bold' as const,
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+    marginBottom: '0.4rem',
+    fontSize: '0.85rem',
+  },
+  quest: {
+    marginBottom: '0.3rem',
+  },
+  active: {
+    color: '#90b090',
+    fontSize: '0.82rem',
+    padding: '0.1rem 0',
+  },
+  completed: {
+    color: '#505848',
+    textDecoration: 'line-through' as const,
+    fontSize: '0.82rem',
+    padding: '0.1rem 0',
+  },
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App.tsx'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/frontend/src/types/game.ts
+++ b/frontend/src/types/game.ts
@@ -1,0 +1,32 @@
+export interface QuestInfo {
+  active: string[];
+  completed: string[];
+  done: boolean;
+}
+
+export interface StateSnapshot {
+  location_id: string;
+  location_name: string;
+  location_description: string;
+  inventory: string[];
+  quests: Record<string, QuestInfo>;
+  turn_number: number;
+}
+
+export interface SessionResponse {
+  session_id: string;
+  state: StateSnapshot;
+}
+
+export interface TurnResponse {
+  success: boolean;
+  narration: string;
+  state: StateSnapshot;
+}
+
+export interface LogEntry {
+  id: number;
+  input: string;
+  narration: string;
+  success: boolean;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
+})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,19 +11,24 @@ requires-python = ">=3.12"
 dependencies = [
   "alembic>=1.14,<2.0",
   "dspy>=2.6,<3.0",
+  "fastapi>=0.115,<0.116",
   "pydantic-settings>=2.7,<3.0",
   "rich>=13.9,<14.0",
   "sqlalchemy>=2.0,<3.0",
+  "uvicorn[standard]>=0.34",
 ]
 
 [project.optional-dependencies]
 dev = [
+  "httpx>=0.28",
   "pytest>=8.3,<9.0",
+  "pytest-asyncio>=0.24",
   "ruff>=0.11,<0.12",
 ]
 
 [project.scripts]
 structured-freedom = "structured_freedom.client.cli:main"
+structured-freedom-api = "structured_freedom.app.main:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
@@ -41,6 +46,10 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "UP", "N", "SIM"]
+ignore = [
+  "B008",   # FastAPI Depends() in default arguments is idiomatic
+  "E501",   # Line length enforced by formatter, not checker
+]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/structured_freedom/ai/__init__.py
+++ b/src/structured_freedom/ai/__init__.py
@@ -1,0 +1,1 @@
+"""AI layer: DSPy modules for intent interpretation, narration, and NPC dialogue."""

--- a/src/structured_freedom/ai/dialogue.py
+++ b/src/structured_freedom/ai/dialogue.py
@@ -1,0 +1,73 @@
+"""DSPy module for AI-driven NPC dialogue."""
+
+from __future__ import annotations
+
+import dspy
+
+from structured_freedom.models.npc import NPCDialogueContext
+
+
+class _DialogueSignature(dspy.Signature):
+    """Generate an NPC's in-character response in a medieval fantasy text adventure.
+
+    Stay in character. Ground the response in the NPC's role, disposition, and
+    recent memories. Be concise (1–3 sentences). Do not break the fourth wall.
+    If the NPC is hostile, be curt or threatening. If friendly, be warm.
+    """
+
+    npc_name: str = dspy.InputField(desc="The NPC's name.")
+    npc_role: str = dspy.InputField(desc="The NPC's role in the world (e.g. 'innkeeper', 'guard').")
+    npc_disposition: str = dspy.InputField(
+        desc="Current disposition: 'friendly', 'neutral', or 'hostile'."
+    )
+    npc_state_summary: str = dspy.InputField(
+        desc="Key facts about the NPC's current state (what they know, what they want)."
+    )
+    recent_memories: str = dspy.InputField(
+        desc="Recent interactions with the player, comma-separated. Empty string if none."
+    )
+    player_speech: str = dspy.InputField(
+        desc="What the player said or asked."
+    )
+
+    response: str = dspy.OutputField(
+        desc="The NPC's in-character spoken response, 1–3 sentences."
+    )
+    mood_hint: str = dspy.OutputField(
+        desc=(
+            "Optional disposition shift hint: 'more_friendly', 'more_hostile', or 'unchanged'. "
+            "Only shift if the player's speech clearly warrants it."
+        )
+    )
+
+
+class NPCDialogue(dspy.Module):
+    """Generates NPC dialogue grounded in character state and player interaction."""
+
+    def __init__(self) -> None:
+        self.predict = dspy.Predict(_DialogueSignature)
+
+    def forward(self, context: NPCDialogueContext, player_speech: str) -> tuple[str, str]:
+        """Return (npc_response_text, mood_hint)."""
+        state_summary = "; ".join(
+            f"{k}={v}" for k, v in context.state.items()
+        ) or "nothing notable"
+
+        memories_text = ", ".join(
+            entry.summary for entry in context.recent_memories[-3:]
+        ) if context.recent_memories else ""
+
+        result = self.predict(
+            npc_name=context.name,
+            npc_role=context.role,
+            npc_disposition=context.disposition,
+            npc_state_summary=state_summary,
+            recent_memories=memories_text,
+            player_speech=player_speech,
+        )
+
+        mood_hint = result.mood_hint.strip().lower()
+        if mood_hint not in {"more_friendly", "more_hostile", "unchanged"}:
+            mood_hint = "unchanged"
+
+        return result.response.strip(), mood_hint

--- a/src/structured_freedom/ai/intent.py
+++ b/src/structured_freedom/ai/intent.py
@@ -1,0 +1,86 @@
+"""DSPy module for interpreting player natural language into structured game intent."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import dspy
+from pydantic import BaseModel
+
+ActionType = Literal["move", "take", "drop", "use", "examine", "talk", "custom", "invalid"]
+
+
+class ParsedIntent(BaseModel):
+    """Structured representation of a player action after AI interpretation."""
+
+    action_type: ActionType
+    target: str
+    parameters: dict[str, str]
+    is_plausible: bool
+    rejection_reason: str
+
+
+class _IntentSignature(dspy.Signature):
+    """Parse a player's free-form action into a structured game command.
+
+    You are the intent parser for a medieval fantasy text adventure.
+    Classify the action and identify its target. Reject actions that are
+    physically impossible in a low-fantasy medieval world (no magic, no
+    modern technology, no teleportation unless the world explicitly allows it).
+    """
+
+    world_context: str = dspy.InputField(
+        desc="Brief description of the player's current location, nearby NPCs, and visible items."
+    )
+    player_action: str = dspy.InputField(
+        desc="The raw natural-language action the player typed."
+    )
+
+    action_type: str = dspy.OutputField(
+        desc=(
+            "One of: move, take, drop, use, examine, talk, custom, invalid. "
+            "Use 'custom' for valid but non-standard actions (e.g. 'poop', 'sit down'). "
+            "Use 'invalid' for physically impossible or world-breaking actions."
+        )
+    )
+    target: str = dspy.OutputField(
+        desc=(
+            "The primary target of the action. For move: a direction (north/south/east/west). "
+            "For take/drop/use/examine: an item name or 'location'. "
+            "For talk: an NPC name. For custom/invalid: a brief noun phrase or 'none'."
+        )
+    )
+    is_plausible: str = dspy.OutputField(
+        desc="'true' if the action is physically possible in a medieval world, 'false' otherwise."
+    )
+    rejection_reason: str = dspy.OutputField(
+        desc="If not plausible, a short in-world reason. Empty string if plausible."
+    )
+
+
+class IntentInterpreter(dspy.Module):
+    """Interprets free-form player text into a structured ParsedIntent."""
+
+    def __init__(self) -> None:
+        self.predict = dspy.Predict(_IntentSignature)
+
+    def forward(self, player_action: str, world_context: str) -> ParsedIntent:
+        result = self.predict(
+            world_context=world_context,
+            player_action=player_action,
+        )
+
+        action_type = result.action_type.strip().lower()
+        valid_types = {"move", "take", "drop", "use", "examine", "talk", "custom", "invalid"}
+        if action_type not in valid_types:
+            action_type = "custom"
+
+        is_plausible = result.is_plausible.strip().lower() not in {"false", "no", "0"}
+
+        return ParsedIntent(
+            action_type=action_type,  # type: ignore[arg-type]
+            target=result.target.strip().lower(),
+            parameters={},
+            is_plausible=is_plausible,
+            rejection_reason=result.rejection_reason.strip(),
+        )

--- a/src/structured_freedom/ai/narrator.py
+++ b/src/structured_freedom/ai/narrator.py
@@ -1,0 +1,44 @@
+"""DSPy module for generating atmospheric prose narration from action results."""
+
+from __future__ import annotations
+
+import dspy
+
+from structured_freedom.engine.actions import ActionResult
+
+
+class _NarrationSignature(dspy.Signature):
+    """Generate atmospheric narration for a medieval fantasy text adventure.
+
+    You are the narrator. Write in second person, present tense. Be vivid but
+    concise (2–4 sentences). Do not invent facts not present in the action
+    result or world context. If the action failed, explain why in-world.
+    """
+
+    world_context: str = dspy.InputField(
+        desc="Current location description and relevant world details."
+    )
+    action_result_summary: str = dspy.InputField(
+        desc="What happened: action type, target, success/failure, and the system message."
+    )
+
+    narration: str = dspy.OutputField(
+        desc="Atmospheric prose narration in second person, present tense, 2–4 sentences."
+    )
+
+
+class Narrator(dspy.Module):
+    """Generates atmospheric prose from a validated ActionResult."""
+
+    def __init__(self) -> None:
+        self.predict = dspy.Predict(_NarrationSignature)
+
+    def forward(self, result: ActionResult, world_context: str) -> str:
+        status = "succeeded" if result.success else "failed"
+        summary = f"Action {status}. {result.message}"
+
+        prediction = self.predict(
+            world_context=world_context,
+            action_result_summary=summary,
+        )
+        return prediction.narration.strip()

--- a/src/structured_freedom/ai/provider.py
+++ b/src/structured_freedom/ai/provider.py
@@ -1,0 +1,41 @@
+"""DSPy language model configuration from application settings."""
+
+from __future__ import annotations
+
+import dspy
+
+from structured_freedom.config.settings import Settings, get_settings
+
+_configured = False
+
+
+def configure_lm(settings: Settings | None = None) -> dspy.LM:
+    """Configure and return the DSPy language model from settings.
+
+    Calling this more than once with the same settings is safe — DSPy
+    re-registers the global LM on every call but the object is lightweight.
+    """
+    active = settings or get_settings()
+
+    if active.ai_provider == "ollama":
+        model_string = f"ollama_chat/{active.ai_default_model}"
+        lm = dspy.LM(
+            model=model_string,
+            api_base=active.ollama_base_url,
+            api_key="ollama",
+        )
+    elif active.ai_provider == "openai":
+        lm = dspy.LM(
+            model=f"openai/{active.ai_default_model}",
+            api_key=active.openai_api_key,
+        )
+    elif active.ai_provider == "anthropic":
+        lm = dspy.LM(
+            model=f"anthropic/{active.ai_default_model}",
+            api_key=active.anthropic_api_key,
+        )
+    else:
+        raise ValueError(f"Unsupported AI provider: {active.ai_provider!r}")
+
+    dspy.configure(lm=lm)
+    return lm

--- a/src/structured_freedom/app/api/__init__.py
+++ b/src/structured_freedom/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI application and routers."""

--- a/src/structured_freedom/app/api/app.py
+++ b/src/structured_freedom/app/api/app.py
@@ -1,0 +1,53 @@
+"""FastAPI application factory."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from structured_freedom.app.api.routes import get_db, router
+from structured_freedom.config.settings import get_settings
+from structured_freedom.logging import configure_logging
+from structured_freedom.persistence.database import create_session_factory, init_db
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings = get_settings()
+    configure_logging(settings.log_level)
+    init_db(settings)
+    session_factory = create_session_factory(settings)
+
+    def _get_db():
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _get_db
+    yield
+    app.dependency_overrides.clear()
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="Structured Freedom",
+        description="AI-powered MUD engine API",
+        version="0.1.0",
+        lifespan=lifespan,
+    )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5173", "http://localhost:3000"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.include_router(router)
+    return app
+
+
+app = create_app()

--- a/src/structured_freedom/app/api/routes.py
+++ b/src/structured_freedom/app/api/routes.py
@@ -1,0 +1,129 @@
+"""FastAPI routers for session management and turn execution."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session as DbSession
+
+from structured_freedom.app.api.schemas import (
+    CreateSessionRequest,
+    SessionResponse,
+    StateSnapshot,
+    TurnRequest,
+    TurnResponse,
+)
+from structured_freedom.app.turns import run_turn_full
+from structured_freedom.persistence.repositories.game_repo import GameRepository
+from structured_freedom.world.fixtures import build_npcs, build_world
+from structured_freedom.world.scenario import build_player
+
+router = APIRouter(prefix="/api")
+
+
+def _snapshot_from_session(session, world_data=None) -> StateSnapshot:
+    player = session.player
+    location = session.world.locations.get(player.current_location)
+    return StateSnapshot(
+        location_id=player.current_location,
+        location_name=location.name if location else "",
+        location_description=location.description if location else "",
+        inventory=list(player.inventory),
+        quests={
+            qid: {
+                "active": qs.active_objectives,
+                "completed": qs.completed_objectives,
+                "done": qs.is_completed,
+            }
+            for qid, qs in player.quests.items()
+        },
+        turn_number=session.turn_number,
+    )
+
+
+def get_db() -> DbSession:
+    """FastAPI dependency — overridden in tests and at app startup."""
+    raise RuntimeError("Database dependency not configured. Call configure_db() at startup.")
+
+
+_db_factory = None
+
+
+def configure_db(session_factory) -> None:
+    """Set the database session factory used by the dependency."""
+    global _db_factory, get_db
+
+    def _get_db():
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    get_db.__code__ = _get_db.__code__
+    router.dependency_overrides = {}
+
+
+@router.post("/sessions", response_model=SessionResponse, status_code=201)
+def create_session(
+    body: CreateSessionRequest,
+    db: DbSession = Depends(get_db),
+) -> SessionResponse:
+    repo = GameRepository(db)
+    player = build_player(name=body.player_name)
+    world = build_world()
+    npcs = build_npcs()
+    session = repo.create_session(player=player, world=world, npcs=npcs)
+    return SessionResponse(
+        session_id=session.id,
+        state=_snapshot_from_session(session),
+    )
+
+
+@router.get("/sessions/{session_id}", response_model=SessionResponse)
+def get_session(
+    session_id: str,
+    db: DbSession = Depends(get_db),
+) -> SessionResponse:
+    repo = GameRepository(db)
+    session = repo.load_session(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found.")
+    return SessionResponse(
+        session_id=session.id,
+        state=_snapshot_from_session(session),
+    )
+
+
+@router.post("/sessions/{session_id}/turns", response_model=TurnResponse)
+def execute_turn(
+    session_id: str,
+    body: TurnRequest,
+    db: DbSession = Depends(get_db),
+) -> TurnResponse:
+    if not body.action.strip():
+        raise HTTPException(status_code=422, detail="Action must not be empty.")
+    repo = GameRepository(db)
+    session = repo.load_session(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found.")
+
+    result = run_turn_full(
+        action_text=body.action,
+        session=session,
+        repo=repo,
+        use_ai=True,
+    )
+
+    snapshot = result["state_snapshot"]
+    return TurnResponse(
+        success=result["success"],
+        narration=result["narration"],
+        state=StateSnapshot(
+            location_id=snapshot["location_id"],
+            location_name=snapshot["location_name"],
+            location_description=snapshot["location_description"],
+            inventory=snapshot["inventory"],
+            quests=snapshot["quests"],
+            turn_number=snapshot["turn_number"],
+        ),
+    )

--- a/src/structured_freedom/app/api/schemas.py
+++ b/src/structured_freedom/app/api/schemas.py
@@ -1,0 +1,33 @@
+"""Pydantic request/response schemas for the API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class CreateSessionRequest(BaseModel):
+    player_name: str = "Traveller"
+
+
+class StateSnapshot(BaseModel):
+    location_id: str
+    location_name: str
+    location_description: str
+    inventory: list[str]
+    quests: dict[str, dict]
+    turn_number: int
+
+
+class SessionResponse(BaseModel):
+    session_id: str
+    state: StateSnapshot
+
+
+class TurnRequest(BaseModel):
+    action: str
+
+
+class TurnResponse(BaseModel):
+    success: bool
+    narration: str
+    state: StateSnapshot

--- a/src/structured_freedom/app/main.py
+++ b/src/structured_freedom/app/main.py
@@ -1,0 +1,20 @@
+"""Entry point for the FastAPI development server."""
+
+import uvicorn
+
+from structured_freedom.app.api.app import app
+from structured_freedom.config.settings import get_settings
+
+
+def main() -> None:
+    settings = get_settings()
+    uvicorn.run(
+        "structured_freedom.app.api.app:app",
+        host=settings.api_host,
+        port=settings.api_port,
+        reload=settings.app_env == "development",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/structured_freedom/app/turns.py
+++ b/src/structured_freedom/app/turns.py
@@ -1,16 +1,203 @@
-"""Turn orchestration for the MVP scaffold."""
+"""Full turn pipeline: intent → validation → state mutation → narration → persistence."""
 
+from __future__ import annotations
+
+import json
 import logging
 
+from structured_freedom.ai.dialogue import NPCDialogue
+from structured_freedom.ai.intent import IntentInterpreter
+from structured_freedom.ai.narrator import Narrator
 from structured_freedom.engine.actions import ActionResult
 from structured_freedom.engine.validator import validate_player_action
+from structured_freedom.engine.world_validators import (
+    resolve_drop,
+    resolve_move,
+    resolve_take,
+    validate_drop,
+    validate_examine,
+    validate_move,
+    validate_take,
+    validate_talk,
+    validate_use,
+)
 
 logger = logging.getLogger(__name__)
 
 
 def run_turn(action_text: str) -> ActionResult:
-    """Execute a minimal turn pipeline."""
+    """Thin wrapper for backward-compatible CLI use (no DB, no AI)."""
     logger.info("player_action=%r", action_text)
     result = validate_player_action(action_text)
     logger.info("validation_success=%s message=%r", result.success, result.message)
     return result
+
+
+def _build_world_context(session) -> str:  # type: ignore[return]
+    from structured_freedom.persistence.repositories.game_repo import GameSession
+
+    if not isinstance(session, GameSession):
+        return "Unknown location."
+
+    world = session.world
+    player = session.player
+    location = world.locations.get(player.current_location)
+    if not location:
+        return "Unknown location."
+
+    items_here = [item.name for item in world.items_at(player.current_location)]
+    npcs_here = [
+        n.name for n in session.npcs.values()
+        if n.current_location == player.current_location
+    ]
+    exits = list(location.connections.keys())
+
+    parts = [f"You are in {location.name}. {location.description}"]
+    if items_here:
+        parts.append(f"Visible items: {', '.join(items_here)}.")
+    if npcs_here:
+        parts.append(f"People here: {', '.join(npcs_here)}.")
+    if exits:
+        parts.append(f"Exits: {', '.join(exits)}.")
+    return " ".join(parts)
+
+
+def _dispatch_intent(intent, session) -> ActionResult:
+    """Route a parsed intent to the appropriate engine validator/resolver."""
+    player = session.player
+    world = session.world
+
+    if intent.action_type == "move":
+        result = validate_move(player, world, intent.target)
+        if result.success:
+            resolve_move(player, world, intent.target)
+        return result
+
+    if intent.action_type == "take":
+        result = validate_take(player, world, intent.target)
+        if result.success:
+            resolve_take(player, world, intent.target)
+        return result
+
+    if intent.action_type == "drop":
+        result = validate_drop(player, world, intent.target)
+        if result.success:
+            resolve_drop(player, world, intent.target)
+        return result
+
+    if intent.action_type == "use":
+        return validate_use(player, world, intent.target)
+
+    if intent.action_type == "examine":
+        return validate_examine(player, world, intent.target)
+
+    if intent.action_type == "talk":
+        return validate_talk(player, world, intent.target, session.npcs)
+
+    if intent.action_type == "custom":
+        return ActionResult(
+            success=True,
+            message=f"You attempt to {intent.target}.",
+        )
+
+    return ActionResult(
+        success=False,
+        message=intent.rejection_reason or "That is not possible in this world.",
+    )
+
+
+def run_turn_full(
+    action_text: str,
+    session,
+    repo,
+    use_ai: bool = True,
+) -> dict:
+    """Execute a complete turn with AI, engine, persistence, and narration."""
+    logger.info("session=%s turn=%d input=%r", session.id, session.turn_number, action_text)
+
+    world_context = _build_world_context(session)
+    parsed_intent = None
+    npc_response: str | None = None
+
+    if use_ai:
+        try:
+            interpreter = IntentInterpreter()
+            parsed_intent = interpreter.forward(
+                player_action=action_text,
+                world_context=world_context,
+            )
+            logger.info(
+                "intent=%s target=%s plausible=%s",
+                parsed_intent.action_type,
+                parsed_intent.target,
+                parsed_intent.is_plausible,
+            )
+        except Exception:
+            logger.exception("Intent interpretation failed; falling back to basic validator.")
+
+    if parsed_intent is None:
+        result = validate_player_action(action_text)
+    elif not parsed_intent.is_plausible:
+        result = ActionResult(
+            success=False,
+            message=parsed_intent.rejection_reason or "That is not possible in this world.",
+        )
+    else:
+        result = _dispatch_intent(parsed_intent, session)
+
+    narration = result.message
+
+    if use_ai:
+        try:
+            if result.success and parsed_intent and parsed_intent.action_type == "talk":
+                npc_id = result.state_changes.get("talk_target", "")
+                npc = session.npcs.get(npc_id)
+                if npc:
+                    ctx = npc.build_dialogue_context()
+                    npc_response, mood_hint = NPCDialogue().forward(ctx, action_text)
+                    if mood_hint == "more_friendly" and npc.disposition == "neutral":
+                        npc.disposition = "friendly"
+                    elif mood_hint == "more_hostile" and npc.disposition == "neutral":
+                        npc.disposition = "hostile"
+                    npc.memory.add_entry(
+                        summary=f"Player said: {action_text[:80]}",
+                        turn_number=session.turn_number,
+                    )
+                    narration = npc_response
+            else:
+                narration = Narrator().forward(result, world_context)
+        except Exception:
+            logger.exception("Narration/dialogue failed; using engine message.")
+
+    session.turn_number += 1
+    repo.save_session(session)
+    repo.append_turn(
+        session_id=session.id,
+        turn_number=session.turn_number,
+        raw_input=action_text,
+        parsed_intent_json=parsed_intent.model_dump_json() if parsed_intent else None,
+        validation_success=result.success,
+        state_changes_json=json.dumps(result.state_changes),
+        narration=narration,
+    )
+
+    location = session.world.locations.get(session.player.current_location)
+    return {
+        "success": result.success,
+        "narration": narration,
+        "state_snapshot": {
+            "location_id": session.player.current_location,
+            "location_name": location.name if location else "",
+            "location_description": location.description if location else "",
+            "inventory": session.player.inventory,
+            "quests": {
+                qid: {
+                    "active": qs.active_objectives,
+                    "completed": qs.completed_objectives,
+                    "done": qs.is_completed,
+                }
+                for qid, qs in session.player.quests.items()
+            },
+            "turn_number": session.turn_number,
+        },
+    }

--- a/src/structured_freedom/config/settings.py
+++ b/src/structured_freedom/config/settings.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
     app_env: str = Field(default="development", alias="APP_ENV")
     log_level: str = Field(default="INFO", alias="LOG_LEVEL")
     database_url: str = Field(
-        default="sqlite+pysqlite:///:memory:",
+        default="sqlite+pysqlite:///structured_freedom.db",
         alias="DATABASE_URL",
     )
     ai_provider: str = Field(default="ollama", alias="AI_PROVIDER")
@@ -21,6 +21,10 @@ class Settings(BaseSettings):
         default="http://localhost:11434",
         alias="OLLAMA_BASE_URL",
     )
+    openai_api_key: str = Field(default="", alias="OPENAI_API_KEY")
+    anthropic_api_key: str = Field(default="", alias="ANTHROPIC_API_KEY")
+    api_host: str = Field(default="0.0.0.0", alias="API_HOST")
+    api_port: int = Field(default=8000, alias="API_PORT")
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/src/structured_freedom/engine/actions.py
+++ b/src/structured_freedom/engine/actions.py
@@ -1,6 +1,9 @@
-"""Action result models for the MVP scaffold."""
+"""Action result and intent models for the engine."""
 
-from dataclasses import dataclass
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass(slots=True)
@@ -9,3 +12,4 @@ class ActionResult:
 
     success: bool
     message: str
+    state_changes: dict[str, Any] = field(default_factory=dict)

--- a/src/structured_freedom/engine/world_validators.py
+++ b/src/structured_freedom/engine/world_validators.py
@@ -172,3 +172,76 @@ def validate_use(player: Player, world: WorldState, item_id: str) -> ActionResul
         success=True,
         message=f"You use {item.name}.",
     )
+
+
+# ---------------------------------------------------------------------------
+# Examine
+# ---------------------------------------------------------------------------
+
+
+def validate_examine(
+    player: Player, world: WorldState, target: str
+) -> ActionResult:
+    """Check whether *target* is examinable from the player's current location."""
+    if target == "location" or target in {"here", "around", "room", ""}:
+        location = world.locations.get(player.current_location)
+        if location is None:
+            return ActionResult(success=False, message="You seem to be nowhere.")
+        return ActionResult(
+            success=True,
+            message=f"{location.name}: {location.description}",
+            state_changes={"examined": "location", "location_id": player.current_location},
+        )
+
+    for item in world.items_at(player.current_location):
+        if target in {item.id.lower(), item.name.lower()}:
+            return ActionResult(
+                success=True,
+                message=f"{item.name}: {item.description}",
+                state_changes={"examined": "item", "item_id": item.id},
+            )
+    for item_id in player.inventory:
+        item = world.items.get(item_id)
+        if item and target in {item.id.lower(), item.name.lower()}:
+            return ActionResult(
+                success=True,
+                message=f"{item.name}: {item.description}",
+                state_changes={"examined": "item", "item_id": item.id},
+            )
+
+    return ActionResult(
+        success=False,
+        message=f"You don't see {target!r} here.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Talk
+# ---------------------------------------------------------------------------
+
+
+def validate_talk(
+    player: Player, world: WorldState, npc_id: str, npcs: dict
+) -> ActionResult:
+    """Check whether the player can talk to an NPC at the current location."""
+    npc = npcs.get(npc_id)
+    if npc is None:
+        npc = next(
+            (n for n in npcs.values() if n.name.lower() == npc_id.lower()),
+            None,
+        )
+    if npc is None:
+        return ActionResult(
+            success=False,
+            message=f"There's nobody called {npc_id!r} here.",
+        )
+    if npc.current_location != player.current_location:
+        return ActionResult(
+            success=False,
+            message=f"{npc.name} is not here.",
+        )
+    return ActionResult(
+        success=True,
+        message=f"You approach {npc.name}.",
+        state_changes={"talk_target": npc.id},
+    )

--- a/src/structured_freedom/persistence/database.py
+++ b/src/structured_freedom/persistence/database.py
@@ -1,22 +1,32 @@
 """Database bootstrap helpers."""
 
 from sqlalchemy import create_engine
-from sqlalchemy.orm import DeclarativeBase, sessionmaker
+from sqlalchemy.orm import sessionmaker
 
 from structured_freedom.config.settings import Settings, get_settings
-
-
-class Base(DeclarativeBase):
-    """Base SQLAlchemy declarative model."""
+from structured_freedom.persistence.orm.models import Base
 
 
 def create_db_engine(settings: Settings | None = None):
     """Create a SQLAlchemy engine from settings."""
     active_settings = settings or get_settings()
-    return create_engine(active_settings.database_url, future=True)
+    connect_args = {}
+    if "sqlite" in active_settings.database_url:
+        connect_args["check_same_thread"] = False
+    return create_engine(
+        active_settings.database_url,
+        future=True,
+        connect_args=connect_args,
+    )
 
 
 def create_session_factory(settings: Settings | None = None):
     """Create a SQLAlchemy session factory."""
     engine = create_db_engine(settings)
     return sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+
+
+def init_db(settings: Settings | None = None) -> None:
+    """Create all tables if they don't exist."""
+    engine = create_db_engine(settings)
+    Base.metadata.create_all(engine)

--- a/src/structured_freedom/persistence/orm/__init__.py
+++ b/src/structured_freedom/persistence/orm/__init__.py
@@ -1,0 +1,1 @@
+"""SQLAlchemy ORM table definitions."""

--- a/src/structured_freedom/persistence/orm/models.py
+++ b/src/structured_freedom/persistence/orm/models.py
@@ -1,0 +1,47 @@
+"""SQLAlchemy ORM table definitions for Structured Freedom."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+class SessionRow(Base):
+    """Persisted game session: canonical player + world + NPC state."""
+
+    __tablename__ = "sessions"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    player_json: Mapped[str] = mapped_column(Text, nullable=False)
+    world_json: Mapped[str] = mapped_column(Text, nullable=False)
+    npcs_json: Mapped[str] = mapped_column(Text, nullable=False)
+    turn_number: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now, onupdate=_now)
+
+
+class TurnRow(Base):
+    """Append-only record of a single executed turn."""
+
+    __tablename__ = "turns"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    session_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    turn_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    raw_input: Mapped[str] = mapped_column(Text, nullable=False)
+    parsed_intent_json: Mapped[str] = mapped_column(Text, nullable=True)
+    validation_success: Mapped[int] = mapped_column(Integer, nullable=False)
+    state_changes_json: Mapped[str] = mapped_column(Text, nullable=True)
+    narration: Mapped[str] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)

--- a/src/structured_freedom/persistence/repositories/__init__.py
+++ b/src/structured_freedom/persistence/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Repository pattern for canonical game state persistence."""

--- a/src/structured_freedom/persistence/repositories/game_repo.py
+++ b/src/structured_freedom/persistence/repositories/game_repo.py
@@ -1,0 +1,116 @@
+"""Repository for loading and saving game sessions."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session as DbSession
+
+from structured_freedom.models.npc import NPC
+from structured_freedom.models.player import Player
+from structured_freedom.models.world_state import WorldState
+from structured_freedom.persistence.orm.models import SessionRow, TurnRow
+
+
+@dataclass
+class GameSession:
+    """In-memory representation of a full game session."""
+
+    id: str
+    player: Player
+    world: WorldState
+    npcs: dict[str, NPC]
+    turn_number: int = 0
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+class GameRepository:
+    """Loads and saves game sessions using a SQLAlchemy session."""
+
+    def __init__(self, db: DbSession) -> None:
+        self._db = db
+
+    def create_session(
+        self,
+        player: Player,
+        world: WorldState,
+        npcs: dict[str, NPC],
+    ) -> GameSession:
+        session_id = str(uuid.uuid4())
+        row = SessionRow(
+            id=session_id,
+            player_json=player.model_dump_json(),
+            world_json=world.model_dump_json(),
+            npcs_json=json.dumps({k: v.model_dump() for k, v in npcs.items()}),
+            turn_number=0,
+        )
+        self._db.add(row)
+        self._db.commit()
+        return GameSession(
+            id=session_id,
+            player=player,
+            world=world,
+            npcs=npcs,
+            turn_number=0,
+        )
+
+    def load_session(self, session_id: str) -> GameSession | None:
+        row = self._db.get(SessionRow, session_id)
+        if row is None:
+            return None
+        player = Player.model_validate_json(row.player_json)
+        world = WorldState.model_validate_json(row.world_json)
+        raw_npcs = json.loads(row.npcs_json)
+        npcs = {k: NPC.model_validate(v) for k, v in raw_npcs.items()}
+        return GameSession(
+            id=row.id,
+            player=player,
+            world=world,
+            npcs=npcs,
+            turn_number=row.turn_number,
+            created_at=row.created_at,
+        )
+
+    def save_session(self, session: GameSession) -> None:
+        row = self._db.get(SessionRow, session.id)
+        if row is None:
+            raise ValueError(f"Session {session.id!r} not found.")
+        row.player_json = session.player.model_dump_json()
+        row.world_json = session.world.model_dump_json()
+        row.npcs_json = json.dumps({k: v.model_dump() for k, v in session.npcs.items()})
+        row.turn_number = session.turn_number
+        self._db.commit()
+
+    def append_turn(
+        self,
+        session_id: str,
+        turn_number: int,
+        raw_input: str,
+        parsed_intent_json: str | None,
+        validation_success: bool,
+        state_changes_json: str | None,
+        narration: str | None,
+    ) -> None:
+        row = TurnRow(
+            session_id=session_id,
+            turn_number=turn_number,
+            raw_input=raw_input,
+            parsed_intent_json=parsed_intent_json,
+            validation_success=int(validation_success),
+            state_changes_json=state_changes_json,
+            narration=narration,
+        )
+        self._db.add(row)
+        self._db.commit()
+
+    def get_turns(self, session_id: str, limit: int = 20) -> list[TurnRow]:
+        return (
+            self._db.query(TurnRow)
+            .filter(TurnRow.session_id == session_id)
+            .order_by(TurnRow.turn_number.desc())
+            .limit(limit)
+            .all()
+        )

--- a/src/structured_freedom/world/__init__.py
+++ b/src/structured_freedom/world/__init__.py
@@ -1,0 +1,1 @@
+"""World content: MVP fixtures and scenario definitions."""

--- a/src/structured_freedom/world/fixtures.py
+++ b/src/structured_freedom/world/fixtures.py
@@ -1,0 +1,212 @@
+"""MVP world content: locations, items, and NPCs for the village gate scenario."""
+
+from __future__ import annotations
+
+from structured_freedom.models.item import Item
+from structured_freedom.models.location import Location
+from structured_freedom.models.npc import NPC
+from structured_freedom.models.world_state import WorldState
+
+
+def build_locations() -> dict[str, Location]:
+    return {
+        "village": Location(
+            id="village",
+            name="Village Square",
+            description=(
+                "The heart of Ashford village. A worn stone well stands at the centre. "
+                "Paths branch east toward the Rusty Lantern tavern, south toward the market, "
+                "and north toward the village gate."
+            ),
+            connections={"north": "gate", "east": "tavern", "south": "market"},
+        ),
+        "tavern": Location(
+            id="tavern",
+            name="The Rusty Lantern",
+            description=(
+                "A low-ceilinged common room thick with woodsmoke and the smell of ale. "
+                "Rough-hewn tables fill the floor. A staircase leads up to the rooms above. "
+                "The door back to the village square is to the west."
+            ),
+            connections={"west": "village"},
+        ),
+        "market": Location(
+            id="market",
+            name="Market Stalls",
+            description=(
+                "A handful of canvas-covered stalls selling bread, rope, and curiosities. "
+                "Most are half-empty today. The path back to the village square is north."
+            ),
+            connections={"north": "village"},
+        ),
+        "gate": Location(
+            id="gate",
+            name="Village Gate",
+            description=(
+                "A heavy oak gate marks the northern edge of Ashford. "
+                "A guardhouse stands to one side. The road north leads into the forest. "
+                "The village square is south."
+            ),
+            connections={"south": "village", "north": "forest_edge"},
+        ),
+        "forest_edge": Location(
+            id="forest_edge",
+            name="Forest Edge",
+            description=(
+                "Tall oaks press close on either side. The air is cooler here. "
+                "Something glints in the undergrowth. The gate back to the village is south."
+            ),
+            connections={"south": "gate"},
+        ),
+    }
+
+
+def build_items() -> dict[str, Item]:
+    return {
+        "lantern": Item(
+            id="lantern",
+            name="Rusty Lantern",
+            description="A battered iron lantern. The glass is cracked but it still holds a flame.",
+            location_id="tavern",
+            takeable=True,
+            usable=True,
+        ),
+        "knife": Item(
+            id="knife",
+            name="Paring Knife",
+            description="A small kitchen knife left on a tavern table.",
+            location_id="tavern",
+            takeable=True,
+            usable=True,
+        ),
+        "bread": Item(
+            id="bread",
+            name="Loaf of Bread",
+            description="A dense round loaf, still slightly warm.",
+            location_id="market",
+            takeable=True,
+            usable=True,
+        ),
+        "rope": Item(
+            id="rope",
+            name="Coil of Rope",
+            description="Ten metres of sturdy hemp rope.",
+            location_id="market",
+            takeable=True,
+            usable=True,
+        ),
+        "amulet": Item(
+            id="amulet",
+            name="Silver Amulet",
+            description=(
+                "A small silver amulet shaped like a crescent moon. "
+                "It matches the description of the item stolen from the miller."
+            ),
+            location_id="forest_edge",
+            takeable=True,
+            usable=False,
+        ),
+        "well": Item(
+            id="well",
+            name="Stone Well",
+            description="A deep stone well at the centre of the village square. Cold water shimmers below.",
+            location_id="village",
+            takeable=False,
+            usable=True,
+        ),
+        "notice_board": Item(
+            id="notice_board",
+            name="Notice Board",
+            description=(
+                "A wooden board nailed to a post. A fresh notice reads: "
+                "'By order of the headman — the north gate is closed until the theft from Aldric's mill is resolved.'"
+            ),
+            location_id="village",
+            takeable=False,
+            usable=False,
+        ),
+    }
+
+
+def build_npcs() -> dict[str, NPC]:
+    return {
+        "innkeeper": NPC(
+            id="innkeeper",
+            name="Marta",
+            role="innkeeper",
+            description=(
+                "A stout woman in her fifties with flour on her apron. "
+                "She runs the Rusty Lantern with brisk efficiency."
+            ),
+            current_location="tavern",
+            disposition="friendly",
+            state={
+                "knows_about_theft": "yes",
+                "gossip_shared": "false",
+            },
+        ),
+        "guard": NPC(
+            id="guard",
+            name="Edric",
+            role="gate guard",
+            description=(
+                "A young guard in ill-fitting armour. He looks tired and a little nervous. "
+                "He has been posted at the gate since the theft was discovered."
+            ),
+            current_location="gate",
+            disposition="neutral",
+            state={
+                "gate_locked": "true",
+                "bribeable": "false",
+                "told_player_about_theft": "false",
+            },
+        ),
+        "merchant": NPC(
+            id="merchant",
+            name="Oswin",
+            role="market trader",
+            description=(
+                "A wiry man with sharp eyes who sells rope, bread, and other provisions. "
+                "He is visibly nervous today."
+            ),
+            current_location="market",
+            disposition="neutral",
+            state={
+                "saw_thief": "true",
+                "willing_to_talk": "false",
+            },
+        ),
+        "stranger": NPC(
+            id="stranger",
+            name="The Stranger",
+            role="mysterious traveller",
+            description=(
+                "A cloaked figure nursing a drink alone in the corner of the tavern. "
+                "Their face is hidden. They watch you with quiet interest."
+            ),
+            current_location="tavern",
+            disposition="neutral",
+            state={
+                "knows_thief_identity": "true",
+                "trust_level": "0",
+            },
+        ),
+    }
+
+
+def build_initial_flags() -> dict[str, bool]:
+    return {
+        "gate_north_blocked": True,
+        "theft_resolved": False,
+        "player_met_guard": False,
+        "amulet_recovered": False,
+    }
+
+
+def build_world() -> WorldState:
+    """Build the complete MVP world state from fixtures."""
+    return WorldState(
+        locations=build_locations(),
+        items=build_items(),
+        flags=build_initial_flags(),
+    )

--- a/src/structured_freedom/world/scenario.py
+++ b/src/structured_freedom/world/scenario.py
@@ -1,0 +1,54 @@
+"""MVP quest and scenario definitions for the village gate scenario."""
+
+from __future__ import annotations
+
+from structured_freedom.models.player import Player, PlayerStats, QuestState
+from structured_freedom.world.fixtures import build_world
+
+MAIN_QUEST_ID = "village_gate"
+
+
+def build_main_quest() -> QuestState:
+    return QuestState(
+        quest_id=MAIN_QUEST_ID,
+        active_objectives=[
+            "Learn why the gate is closed",
+            "Recover the stolen amulet",
+            "Return the amulet to open the gate",
+        ],
+        completed_objectives=[],
+        is_completed=False,
+    )
+
+
+def build_player(name: str = "Traveller") -> Player:
+    quest = build_main_quest()
+    player = Player(
+        id="player",
+        name=name,
+        current_location="village",
+        description="A wanderer of uncertain origin.",
+        stats=PlayerStats(strength=3, perception=4, charisma=3),
+        inventory=[],
+        inventory_limit=10,
+    )
+    player.track_quest(quest)
+    return player
+
+
+def build_context_for_location(location_id: str) -> str:
+    """Build a brief world context string for the AI modules."""
+    world = build_world()
+    location = world.locations.get(location_id)
+    if not location:
+        return f"An unknown place with id {location_id!r}."
+
+    items_here = [item.name for item in world.items_at(location_id)]
+    exits = list(location.connections.keys())
+
+    parts = [f"You are in {location.name}. {location.description}"]
+    if items_here:
+        parts.append(f"You can see: {', '.join(items_here)}.")
+    if exits:
+        parts.append(f"Exits: {', '.join(exits)}.")
+    return " ".join(parts)

--- a/tests/ai/test_intent.py
+++ b/tests/ai/test_intent.py
@@ -1,0 +1,89 @@
+"""Tests for intent interpretation contracts — no live LLM required."""
+
+from unittest.mock import MagicMock
+
+import dspy
+
+from structured_freedom.ai.intent import IntentInterpreter, ParsedIntent
+
+
+def _make_prediction(**kwargs):
+    pred = MagicMock(spec=dspy.Prediction)
+    for k, v in kwargs.items():
+        setattr(pred, k, v)
+    return pred
+
+
+class TestIntentInterpreter:
+    def _interpreter_with_mock(self, **prediction_kwargs) -> IntentInterpreter:
+        interpreter = IntentInterpreter()
+        interpreter.predict = MagicMock(return_value=_make_prediction(**prediction_kwargs))
+        return interpreter
+
+    def test_move_action_classified(self):
+        interpreter = self._interpreter_with_mock(
+            action_type="move",
+            target="north",
+            is_plausible="true",
+            rejection_reason="",
+        )
+        result = interpreter.forward("go north", "You are at the village gate.")
+        assert result.action_type == "move"
+        assert result.target == "north"
+        assert result.is_plausible is True
+
+    def test_take_action_classified(self):
+        interpreter = self._interpreter_with_mock(
+            action_type="take",
+            target="lantern",
+            is_plausible="true",
+            rejection_reason="",
+        )
+        result = interpreter.forward("pick up the lantern", "You see a lantern on the table.")
+        assert result.action_type == "take"
+        assert result.target == "lantern"
+
+    def test_absurd_action_rejected(self):
+        interpreter = self._interpreter_with_mock(
+            action_type="invalid",
+            target="rocketship",
+            is_plausible="false",
+            rejection_reason="There are no rocketships in this world.",
+        )
+        result = interpreter.forward(
+            "I build a rocketship and fly away",
+            "You are in the village square.",
+        )
+        assert result.is_plausible is False
+        assert "rocketship" in result.rejection_reason.lower()
+
+    def test_unknown_action_type_falls_back_to_custom(self):
+        interpreter = self._interpreter_with_mock(
+            action_type="weird_unknown_type_xyz",
+            target="nothing",
+            is_plausible="true",
+            rejection_reason="",
+        )
+        result = interpreter.forward("do something odd", "You are somewhere.")
+        assert result.action_type == "custom"
+
+    def test_false_string_variants_treated_as_not_plausible(self):
+        for false_val in ("false", "False", "FALSE", "no", "No", "0"):
+            interpreter = self._interpreter_with_mock(
+                action_type="invalid",
+                target="none",
+                is_plausible=false_val,
+                rejection_reason="Not possible.",
+            )
+            result = interpreter.forward("teleport to the vault", "You are here.")
+            assert result.is_plausible is False, f"Expected False for {false_val!r}"
+
+    def test_result_is_parsed_intent(self):
+        interpreter = self._interpreter_with_mock(
+            action_type="examine",
+            target="notice board",
+            is_plausible="true",
+            rejection_reason="",
+        )
+        result = interpreter.forward("look at the notice board", "There is a notice board here.")
+        assert isinstance(result, ParsedIntent)

--- a/tests/api/test_turns.py
+++ b/tests/api/test_turns.py
@@ -1,0 +1,120 @@
+"""Integration tests for the FastAPI turn and session endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from structured_freedom.app.api.app import create_app
+from structured_freedom.app.api.routes import get_db
+from structured_freedom.persistence.orm.models import Base
+
+
+@pytest.fixture(scope="module")
+def client():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+
+    def override_db():
+        db = factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app = create_app()
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as c:
+        yield c
+
+
+def _mock_intent(action_type: str = "examine", target: str = "location"):
+    intent = MagicMock()
+    intent.action_type = action_type
+    intent.target = target
+    intent.is_plausible = True
+    intent.rejection_reason = ""
+    intent.model_dump_json.return_value = "{}"
+    return intent
+
+
+class TestSessionEndpoints:
+    def test_create_session(self, client):
+        res = client.post("/api/sessions", json={"player_name": "Hero"})
+        assert res.status_code == 201
+        data = res.json()
+        assert "session_id" in data
+        assert data["state"]["location_id"] == "village"
+
+    def test_get_session(self, client):
+        create_res = client.post("/api/sessions", json={"player_name": "Tester"})
+        sid = create_res.json()["session_id"]
+
+        res = client.get(f"/api/sessions/{sid}")
+        assert res.status_code == 200
+        assert res.json()["session_id"] == sid
+
+    def test_get_nonexistent_session_returns_404(self, client):
+        res = client.get("/api/sessions/00000000-0000-0000-0000-000000000000")
+        assert res.status_code == 404
+
+
+class TestTurnEndpoint:
+    def _create_session(self, client):
+        res = client.post("/api/sessions", json={"player_name": "Adventurer"})
+        return res.json()["session_id"]
+
+    def test_valid_action_returns_200(self, client):
+        sid = self._create_session(client)
+        narration = "You look around the village square."
+        with (
+            patch("structured_freedom.app.turns.IntentInterpreter") as mock_interp,
+            patch("structured_freedom.app.turns.Narrator") as mock_narr,
+        ):
+            mock_interp.return_value.forward.return_value = _mock_intent()
+            mock_narr.return_value.forward.return_value = narration
+
+            res = client.post(
+                f"/api/sessions/{sid}/turns", json={"action": "look around"}
+            )
+        assert res.status_code == 200
+        data = res.json()
+        assert "narration" in data
+        assert "state" in data
+
+    def test_empty_action_returns_422(self, client):
+        sid = self._create_session(client)
+        res = client.post(f"/api/sessions/{sid}/turns", json={"action": "   "})
+        assert res.status_code == 422
+
+    def test_nonexistent_session_turn_returns_404(self, client):
+        res = client.post(
+            "/api/sessions/00000000-0000-0000-0000-000000000000/turns",
+            json={"action": "go north"},
+        )
+        assert res.status_code == 404
+
+    def test_turn_increments_turn_number(self, client):
+        sid = self._create_session(client)
+        before = client.get(f"/api/sessions/{sid}").json()["state"]["turn_number"]
+
+        with (
+            patch("structured_freedom.app.turns.IntentInterpreter") as mock_interp,
+            patch("structured_freedom.app.turns.Narrator") as mock_narr,
+        ):
+            mock_interp.return_value.forward.return_value = _mock_intent()
+            mock_narr.return_value.forward.return_value = "You look around."
+            client.post(f"/api/sessions/{sid}/turns", json={"action": "look around"})
+
+        after = client.get(f"/api/sessions/{sid}").json()["state"]["turn_number"]
+        assert after == before + 1

--- a/tests/persistence/test_repositories.py
+++ b/tests/persistence/test_repositories.py
@@ -1,0 +1,105 @@
+"""Repository tests using SQLite in-memory database."""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from structured_freedom.persistence.orm.models import Base
+from structured_freedom.persistence.repositories.game_repo import GameRepository
+from structured_freedom.world.fixtures import build_npcs, build_world
+from structured_freedom.world.scenario import build_player
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    session = factory()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+@pytest.fixture()
+def repo(db):
+    return GameRepository(db)
+
+
+class TestGameRepository:
+    def test_create_and_load_session(self, repo):
+        player = build_player("Test Hero")
+        world = build_world()
+        npcs = build_npcs()
+
+        session = repo.create_session(player=player, world=world, npcs=npcs)
+        assert session.id is not None
+        assert session.turn_number == 0
+
+        loaded = repo.load_session(session.id)
+        assert loaded is not None
+        assert loaded.player.name == "Test Hero"
+        assert loaded.turn_number == 0
+
+    def test_load_nonexistent_session_returns_none(self, repo):
+        result = repo.load_session("00000000-0000-0000-0000-000000000000")
+        assert result is None
+
+    def test_save_session_persists_changes(self, repo):
+        player = build_player()
+        world = build_world()
+        npcs = build_npcs()
+
+        session = repo.create_session(player=player, world=world, npcs=npcs)
+        session.player.move_to("tavern")
+        session.turn_number = 3
+        repo.save_session(session)
+
+        loaded = repo.load_session(session.id)
+        assert loaded.player.current_location == "tavern"
+        assert loaded.turn_number == 3
+
+    def test_append_turn_records_entry(self, repo):
+        player = build_player()
+        world = build_world()
+        npcs = build_npcs()
+        session = repo.create_session(player=player, world=world, npcs=npcs)
+
+        repo.append_turn(
+            session_id=session.id,
+            turn_number=1,
+            raw_input="go north",
+            parsed_intent_json=None,
+            validation_success=True,
+            state_changes_json=None,
+            narration="You walk north.",
+        )
+
+        turns = repo.get_turns(session.id)
+        assert len(turns) == 1
+        assert turns[0].raw_input == "go north"
+
+    def test_world_flags_survive_roundtrip(self, repo):
+        player = build_player()
+        world = build_world()
+        npcs = build_npcs()
+
+        assert world.get_flag("gate_north_blocked") is True
+
+        session = repo.create_session(player=player, world=world, npcs=npcs)
+        loaded = repo.load_session(session.id)
+        assert loaded.world.get_flag("gate_north_blocked") is True
+
+    def test_npc_state_survives_roundtrip(self, repo):
+        player = build_player()
+        world = build_world()
+        npcs = build_npcs()
+
+        session = repo.create_session(player=player, world=world, npcs=npcs)
+        loaded = repo.load_session(session.id)
+        assert "guard" in loaded.npcs
+        assert loaded.npcs["guard"].name == "Edric"

--- a/tests/world/test_fixtures.py
+++ b/tests/world/test_fixtures.py
@@ -1,0 +1,71 @@
+"""Smoke tests for world fixtures and scenario integrity."""
+
+
+from structured_freedom.engine.world_validators import validate_move
+from structured_freedom.world.fixtures import build_npcs, build_world
+from structured_freedom.world.scenario import (
+    MAIN_QUEST_ID,
+    build_main_quest,
+    build_player,
+)
+
+
+class TestWorldFixtures:
+    def test_all_locations_present(self):
+        world = build_world()
+        expected = {"village", "tavern", "market", "gate", "forest_edge"}
+        assert expected == set(world.locations.keys())
+
+    def test_connections_are_bidirectional(self):
+        world = build_world()
+        for loc_id, location in world.locations.items():
+            for _direction, dest_id in location.connections.items():
+                dest = world.locations.get(dest_id)
+                assert dest is not None, f"{loc_id} connects to unknown {dest_id!r}"
+                assert dest_id in world.locations
+
+    def test_gate_north_blocked_flag(self):
+        world = build_world()
+        assert world.get_flag("gate_north_blocked") is True
+
+    def test_gate_north_blocked_prevents_movement(self):
+        from structured_freedom.world.scenario import build_player
+        world = build_world()
+        player = build_player()
+        player.move_to("gate")
+
+        result = validate_move(player, world, "north")
+        assert result.success is False
+        assert "blocked" in result.message.lower()
+
+    def test_items_have_valid_locations(self):
+        world = build_world()
+        for item_id, item in world.items.items():
+            if item.location_id is not None:
+                assert item.location_id in world.locations, (
+                    f"Item {item_id!r} references unknown location {item.location_id!r}"
+                )
+
+    def test_npcs_have_valid_locations(self):
+        world = build_world()
+        npcs = build_npcs()
+        for npc_id, npc in npcs.items():
+            assert npc.current_location in world.locations, (
+                f"NPC {npc_id!r} is in unknown location {npc.current_location!r}"
+            )
+
+
+class TestScenario:
+    def test_player_starts_in_village(self):
+        player = build_player()
+        assert player.current_location == "village"
+
+    def test_main_quest_has_objectives(self):
+        quest = build_main_quest()
+        assert quest.quest_id == MAIN_QUEST_ID
+        assert len(quest.active_objectives) > 0
+        assert not quest.is_completed
+
+    def test_player_has_main_quest(self):
+        player = build_player("Finn")
+        assert MAIN_QUEST_ID in player.quests


### PR DESCRIPTION
## Summary

Full MVP implementation via Daedalus SDLC. This PR takes the existing domain models and engine scaffold and completes the missing stack:

- **AI layer** (`src/structured_freedom/ai/`): DSPy modules for intent interpretation, atmospheric narration, and NPC dialogue — all provider-agnostic via LiteLLM (Ollama/OpenAI/Anthropic)
- **FastAPI backend** (`src/structured_freedom/app/api/`): Session management and turn execution endpoints; full turn pipeline wiring AI → engine → persistence → narration
- **Persistence** (`src/structured_freedom/persistence/`): SQLAlchemy ORM models, `GameRepository` with create/load/save/append_turn, SQLite dev / PostgreSQL prod
- **World content** (`src/structured_freedom/world/`): MVP scenario — 5 locations, 7 items, 4 NPCs (innkeeper/guard/merchant/stranger), village gate quest
- **React/Vite frontend** (`frontend/`): LocationPanel, GameLog, InventoryPanel, QuestPanel, ActionInput; TypeScript API client with Vite proxy
- **Docs**: `requirements.md`, `sprint-backlog.md`, rewritten `architecture.md`, 3 new decision log entries (DEC-0009 React frontend, DEC-0010 LiteLLM, DEC-0011 FastAPI)

## New dependencies (require review per AGENTS.md)

| Package | Version | Reason |
|---------|---------|--------|
| `fastapi` | `>=0.115,<0.116` | HTTP framework (already in architecture doc) |
| `uvicorn[standard]` | `>=0.34` | ASGI server |
| `httpx` | `>=0.28` | Async test client (dev dep) |
| `pytest-asyncio` | `>=0.24` | Async test support (dev dep) |

## Test plan

- [x] 97 pytest tests passing (intent mocks, repository roundtrips, API integration, world fixtures, engine validators)
- [x] `ruff check` passes (no errors beyond E501 which is ignored by config; B008/Depends is FastAPI idiomatic)
- [ ] Manual: `structured-freedom-api` → `npm run dev` in `frontend/` → play the village gate scenario end-to-end (requires Ollama running locally with llama3.1:8b)

## Running locally

```bash
# Backend
pip install -e ".[dev]"
structured-freedom-api
# or: uvicorn structured_freedom.app.api.app:app --reload

# Frontend (separate terminal)
cd frontend
npm install
npm run dev
# → http://localhost:5173
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)